### PR TITLE
Fixed SSR to work on Node 25

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "HDRI Calibration Interface",
   "build": {
     "beforeBuildCommand": "npm run build",
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "NODE_OPTIONS=--no-webstorage npm run dev",
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000/"
   },


### PR DESCRIPTION
Disabled web storage in node to fix failing SSR renders that tried to use it