### PR TITLE
Persist RAW-to-TIFF conversions across reloads (#243)

### DIFF
--- a/__tests__/app-storage.test.ts
+++ b/__tests__/app-storage.test.ts
@@ -10,23 +10,42 @@ import { describe, expect, it } from "@jest/globals";
 
 const documents = new Map<string, unknown>();
 
-jest.mock("../src/lib/storage/kv", () => ({
-  getDocument: (key: string) => {
-    const value = documents.get(key);
-    if (value === "THROW") {
-      return Promise.reject(new Error("store unavailable"));
+jest.mock("../src/lib/storage/kv", () => {
+  // A real subclass, not a bare object shape: F1's fix to `readJson` tells
+  // this class apart with `instanceof`, and a mock that only matched by
+  // duck-typing would leave that check untested against the one thing it
+  // actually has to distinguish. Assigned rather than declared with `class
+  // DatabaseVersionError`, which would shadow the real export this file also
+  // imports by that name for its own assertions.
+  const MockDatabaseVersionError = class extends Error {
+    constructor() {
+      super("stored data is newer than this build can open");
+      this.name = "DatabaseVersionError";
     }
-    return Promise.resolve(value);
-  },
-  putDocument: (key: string, value: unknown) => {
-    documents.set(key, value);
-    return Promise.resolve();
-  },
-}));
+  };
+  return {
+    DatabaseVersionError: MockDatabaseVersionError,
+    getDocument: (key: string) => {
+      const value = documents.get(key);
+      if (value === "THROW") {
+        return Promise.reject(new Error("store unavailable"));
+      }
+      if (value === "VERSION_ERROR") {
+        return Promise.reject(new MockDatabaseVersionError());
+      }
+      return Promise.resolve(value);
+    },
+    putDocument: (key: string, value: unknown) => {
+      documents.set(key, value);
+      return Promise.resolve();
+    },
+  };
+});
 
 declare const jest: typeof import("@jest/globals").jest;
 
 import { readJson, STORAGE_VERSION, writeJson } from "../src/lib/app-storage";
+import { DatabaseVersionError } from "../src/lib/storage/kv";
 
 describe("app storage", () => {
   it("round-trips a value and stamps the version", async () => {
@@ -61,5 +80,17 @@ describe("app storage", () => {
     expect(await readJson("history/old.json", { runs: [] })).toEqual({
       runs: [],
     });
+  });
+
+  it("rethrows DatabaseVersionError instead of returning the fallback", async () => {
+    // F1: a stored-data-is-newer-than-this-build condition is not "nothing
+    // stored badly" -- the data is intact, and papering over it with the
+    // fallback is what used to make a rolled-back deploy render as an empty
+    // app with nothing to explain why.
+    documents.set("history/newer.json", "VERSION_ERROR");
+
+    await expect(
+      readJson("history/newer.json", { runs: [] })
+    ).rejects.toBeInstanceOf(DatabaseVersionError);
   });
 });

--- a/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
+++ b/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
@@ -1152,241 +1152,121 @@ stops a rebuilt dcraw_emu from silently serving the previous demosaic."
 
 ---
 
-### Task 7: The blob store implementation
+### Task 7: The blob store — IndexedDB (approach B, decided by Task 1)
 
-**Run Task 1 first.** Implement whichever approach the probe chose. The steps below are approach **A** (OPFS); if the probe chose **B**, create `src/lib/raw-cache-idb.ts` exporting `idbBlobStore()` with the same `BlobStore` shape, backed by a new `blobs` object store in `kv.ts`, and adapt the commit message.
+**Task 1 decided this.** The probe found `navigator.storage.getDirectory` **absent** in both WebKit (Playwright, CI) and WebKitGTK 605.1.15 (Tauri's Linux webview): `opfsAvailable: false`, `quota: null`. That is not a quota or memory failure — the API does not exist. OPFS worked in Chromium and WebView2. By the rule stated in advance ("OPFS fails or corrupts on **any** engine -> approach B"), two of five engines have no OPFS at all, so approach A is dead. Approach C (OPFS with an IndexedDB fallback) stays rejected: #243 warns that a second caching implementation is the thing that drifts.
+
+IndexedDB round-tripped 67 MB on every engine tested, including both WebKits.
 
 **Files:**
-- Create: `src/lib/raw-cache-opfs.ts`, `src/lib/raw-cache-opfs.test.ts`
-
-**On what the unit test is for.** It cannot prove OPFS works — that is Task 1's
-job, in a real browser. It proves *our use of the API* is right: the correct
-method names, `create: true` where a file must be made, and `close()` on the
-failure path as well as the success one. Those are the mistakes that produce a
-zero-length file that later reads as a corrupt hit rather than a miss, and they
-are invisible to a test that only exercises the happy path.
+- Create: `src/lib/raw-cache-idb.ts`, `src/lib/raw-cache-idb.test.ts`
+- Modify: `src/lib/storage/kv.ts` (a third object store)
 
 **Interfaces:**
 - Consumes: `BlobStore` (Task 4).
-- Produces: `opfsBlobStore(directoryName?: string): BlobStore`, `opfsAvailable(): boolean`.
+- Produces: `idbBlobStore(): BlobStore`, `blobStoreAvailable(): boolean`.
 
-- [ ] **Step 1: Implement**
+**On what the unit test is for.** It proves our *use* of the API: that a written blob reads back identical, that a missing key is `undefined` rather than a throw, and that `keys()` and `remove()` behave. `fake-indexeddb` is already wired (Task 3), so this is testable in Jest directly — unlike OPFS, which was the original reason this task was going to go untested.
+
+- [ ] **Step 1: Add the object store**
+
+In `src/lib/storage/kv.ts`, add beside `DOCUMENTS` and `FILES`:
 
 ```ts
-// src/lib/raw-cache-opfs.ts
+/** Converted RAW frames, by content-addressed key. See `raw-cache.ts`. */
+const BLOBS = "blobs";
+```
+
+Bump the version and create it. The existing `onupgradeneeded` already guards each store with `contains`, so the same handler serves a fresh database and an upgrade from version 1:
+
+```ts
+const DATABASE_VERSION = 2;
+```
+
+```ts
+      if (!database.objectStoreNames.contains(BLOBS)) {
+        database.createObjectStore(BLOBS);
+      }
+```
+
+Then export the three operations the seam needs:
+
+```ts
 /**
- * OPFS backing for the persistent RAW cache.
+ * Reads a cached blob.
  *
- * The only file in the app that touches OPFS, so nothing else has to care
- * that it exists -- and Jest never imports it, since `navigator.storage` is
- * absent under jsdom and a mocked OPFS would only prove the mock works. It is
- * covered by `e2e-web/tests/storage-probe.spec.ts` and by the reload measured
- * in `perf.bench.ts`.
- *
- * Writes go through `createWritable` rather than `createSyncAccessHandle`.
- * The sync handle is faster and is why this tier had to live in a worker at
- * all, but it locks the file for the handle's lifetime, and a lock held across
- * an await is how two callers deadlock. Conversions are already serialised by
- * `raw-worker-client.ts`, so the throughput difference does not reach the user,
- * whereas the deadlock would.
+ * Separate from `getFile` despite the identical shape, because these live in
+ * their own store: the RAW cache evicts on a budget and is cleared wholesale
+ * from the settings page, and neither may touch a preset's calibration files.
  */
-
-import type { BlobStore } from "./raw-cache.types";
-
-const DIRECTORY = "raw-tiff-cache";
-
-/** Whether this host offers OPFS at all. Checked before a store is built. */
-export function opfsAvailable(): boolean {
-  return typeof navigator !== "undefined" &&
-    typeof navigator.storage?.getDirectory === "function";
+export async function getBlob(key: string): Promise<Uint8Array | undefined> {
+  const stored = await run<ArrayBuffer | undefined>(BLOBS, "readonly", (store) =>
+    store.get(key)
+  );
+  return stored ? new Uint8Array(stored) : undefined;
 }
 
-export function opfsBlobStore(directoryName = DIRECTORY): BlobStore {
-  let directory: Promise<FileSystemDirectoryHandle> | undefined;
+export function putBlob(key: string, bytes: Uint8Array): Promise<unknown> {
+  // Stored as ArrayBuffer for the reason `putFile` gives: a view carries its
+  // offset and length, so a subarray of a larger buffer would be cloned whole.
+  return run(BLOBS, "readwrite", (store) =>
+    store.put(
+      bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      ) as ArrayBuffer,
+      key
+    )
+  );
+}
 
-  function open(): Promise<FileSystemDirectoryHandle> {
-    directory ??= navigator.storage
-      .getDirectory()
-      .then((root) => root.getDirectoryHandle(directoryName, { create: true }))
-      .catch((error: unknown) => {
-        // Not remembered: a first failure must not make the cache permanently
-        // unusable for the life of the worker.
-        directory = undefined;
-        throw error;
-      });
-    return directory;
-  }
+export function deleteBlob(key: string): Promise<unknown> {
+  return run(BLOBS, "readwrite", (store) => store.delete(key));
+}
 
-  return {
-    async keys(): Promise<string[]> {
-      const handle = await open();
-      const found: string[] = [];
-      // `keys()` is an async iterator on the directory handle.
-      for await (const name of (
-        handle as unknown as { keys(): AsyncIterable<string> }
-      ).keys()) {
-        found.push(name);
-      }
-      return found;
-    },
-
-    async read(key: string): Promise<Uint8Array | undefined> {
-      const handle = await open();
-      try {
-        const file = await handle.getFileHandle(key);
-        return new Uint8Array(await (await file.getFile()).arrayBuffer());
-      } catch {
-        // NotFoundError is the ordinary miss, and any other read failure is
-        // treated as one: the caller converts, which is always correct.
-        return;
-      }
-    },
-
-    async remove(key: string): Promise<void> {
-      const handle = await open();
-      await handle.removeEntry(key).catch(() => undefined);
-    },
-
-    async write(key: string, bytes: Uint8Array): Promise<void> {
-      const handle = await open();
-      const file = await handle.getFileHandle(key, { create: true });
-      const writable = await file.createWritable();
-      try {
-        await writable.write(bytes as BufferSource);
-      } finally {
-        // Closed on both paths: an unclosed writable leaves a zero-length file
-        // that later reads as a corrupt hit rather than a miss.
-        await writable.close();
-      }
-    },
-  };
+export async function blobKeys(): Promise<string[]> {
+  const keys = await run<IDBValidKey[]>(BLOBS, "readonly", (store) =>
+    store.getAllKeys()
+  );
+  return keys.filter((key): key is string => typeof key === "string");
 }
 ```
 
-- [ ] **Step 2: Write the usage test against a fake handle**
+- [ ] **Step 2: Write the failing test**
 
 ```ts
-// src/lib/raw-cache-opfs.test.ts
-import { opfsBlobStore } from "./raw-cache-opfs";
+// src/lib/raw-cache-idb.test.ts
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { idbBlobStore } from "./raw-cache-idb";
 
-/**
- * A minimal stand-in for the OPFS handles this store drives.
- *
- * Not a claim that OPFS behaves this way -- Task 1's probe is what establishes
- * that, in real browsers. This exists to catch the mistakes a happy-path test
- * cannot see: a missing `create: true`, a writable left unclosed on the error
- * path, a wrong method name.
- */
-function fakeOpfs() {
-  const files = new Map<string, Uint8Array>();
-  const closed: string[] = [];
-  let failNextWrite = false;
-
-  const fileHandle = (name: string) => ({
-    createWritable: () =>
-      Promise.resolve({
-        close: () => {
-          closed.push(name);
-          return Promise.resolve();
-        },
-        write: (bytes: Uint8Array) => {
-          if (failNextWrite) {
-            failNextWrite = false;
-            return Promise.reject(new Error("quota exceeded"));
-          }
-          files.set(name, bytes);
-          return Promise.resolve();
-        },
-      }),
-    getFile: () =>
-      Promise.resolve({
-        arrayBuffer: () => {
-          const stored = files.get(name);
-          if (!stored) {
-            return Promise.reject(new Error("NotFoundError"));
-          }
-          return Promise.resolve(
-            stored.buffer.slice(
-              stored.byteOffset,
-              stored.byteOffset + stored.byteLength
-            )
-          );
-        },
-      }),
+describe("the IndexedDB blob store", () => {
+  beforeEach(async () => {
+    const store = idbBlobStore();
+    for (const key of await store.keys()) {
+      await store.remove(key);
+    }
   });
 
-  const directory = {
-    getFileHandle: (name: string, options?: { create?: boolean }) => {
-      if (!(files.has(name) || options?.create)) {
-        return Promise.reject(new Error("NotFoundError"));
-      }
-      if (options?.create && !files.has(name)) {
-        files.set(name, new Uint8Array());
-      }
-      return Promise.resolve(fileHandle(name));
-    },
-    keys: async function* () {
-      for (const name of Array.from(files.keys())) {
-        yield name;
-      }
-    },
-    removeEntry: (name: string) => {
-      files.delete(name);
-      return Promise.resolve();
-    },
-  };
-
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: {
-      storage: {
-        getDirectory: () =>
-          Promise.resolve({
-            getDirectoryHandle: () => Promise.resolve(directory),
-          }),
-      },
-    },
-  });
-
-  return {
-    closed,
-    files,
-    failWriteOnce: () => {
-      failNextWrite = true;
-    },
-  };
-}
-
-describe("the OPFS blob store", () => {
   it("round-trips bytes through write and read", async () => {
-    fakeOpfs();
-    const store = opfsBlobStore();
+    const store = idbBlobStore();
     await store.write("a", new Uint8Array([1, 2, 3]));
     expect(Array.from((await store.read("a")) ?? [])).toEqual([1, 2, 3]);
   });
 
   it("returns undefined for a key that was never written", async () => {
-    fakeOpfs();
-    expect(await opfsBlobStore().read("absent")).toBeUndefined();
+    expect(await idbBlobStore().read("absent")).toBeUndefined();
   });
 
-  it("closes the writable even when the write fails", async () => {
-    const opfs = fakeOpfs();
-    const store = opfsBlobStore();
-    opfs.failWriteOnce();
-
-    await expect(store.write("b", new Uint8Array([1]))).rejects.toThrow(
-      "quota exceeded"
-    );
-
-    // The point of the test. An unclosed writable leaves a zero-length file
-    // that a later read reports as a hit, serving empty pixels.
-    expect(opfs.closed).toContain("b");
+  it("overwrites an existing key rather than appending", async () => {
+    const store = idbBlobStore();
+    await store.write("a", new Uint8Array([1, 2, 3]));
+    await store.write("a", new Uint8Array([9]));
+    expect(Array.from((await store.read("a")) ?? [])).toEqual([9]);
   });
 
   it("lists and removes keys", async () => {
-    fakeOpfs();
-    const store = opfsBlobStore();
+    const store = idbBlobStore();
     await store.write("a", new Uint8Array([1]));
     await store.write("b", new Uint8Array([2]));
     expect((await store.keys()).toSorted()).toEqual(["a", "b"]);
@@ -1396,30 +1276,98 @@ describe("the OPFS blob store", () => {
   });
 
   it("swallows a removal of something absent", async () => {
-    fakeOpfs();
-    await expect(opfsBlobStore().remove("absent")).resolves.toBeUndefined();
+    await expect(idbBlobStore().remove("absent")).resolves.toBeUndefined();
+  });
+
+  it("stores a view of a larger buffer without dragging the whole buffer in", async () => {
+    // The defect `putFile` documents: a subarray carries its parent's buffer,
+    // so storing the view rather than a slice would persist far more than was
+    // asked for -- and read back the wrong bytes.
+    const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    await idbBlobStore().write("view", backing.subarray(2, 5));
+    expect(Array.from((await idbBlobStore().read("view")) ?? [])).toEqual([
+      3, 4, 5,
+    ]);
   });
 });
 ```
 
-- [ ] **Step 3: Run the test and verify it type-checks**
+- [ ] **Step 3: Run and watch it fail**
 
-Run: `npx jest src/lib/raw-cache-opfs.test.ts && npx tsc --noEmit && npm run check`
-Expected: PASS, five tests, no type or lint errors.
+Run: `npx jest src/lib/raw-cache-idb.test.ts`
+Expected: FAIL — `Cannot find module './raw-cache-idb'`.
 
-Note the `write` test expects a rejection: the store lets a write error
-propagate so `raw-cache.ts` can swallow it in one place, rather than swallowing
-it twice.
+- [ ] **Step 4: Implement**
 
-- [ ] **Step 4: Commit**
+```ts
+// src/lib/raw-cache-idb.ts
+/**
+ * IndexedDB backing for the persistent RAW cache.
+ *
+ * IndexedDB rather than OPFS, and that was measured rather than assumed.
+ * #243 specified OPFS for its `createSyncAccessHandle` fast path; the probe in
+ * `e2e-web/tests/storage-probe.spec.ts` found `navigator.storage.getDirectory`
+ * **absent** in WebKit and in WebKitGTK 605.1.15, the webview Tauri uses on
+ * Linux -- not slow, not quota-limited, simply not implemented. An OPFS cache
+ * would have silently never worked for Safari users or Linux desktop users.
+ * IndexedDB round-tripped a 67 MB blob on every engine tested.
+ *
+ * The cost is a structured clone on each read and write, against roughly 2 s
+ * of demosaic per frame that it avoids. `perf.bench.ts` measures the result
+ * rather than assuming it.
+ *
+ * A second consequence worth knowing: blobs and index now live in the same
+ * database, so the reconciliation in `raw-cache.ts` guards a narrower window
+ * than it was designed for. It is kept because the two are still written in
+ * separate transactions, so a crash between them remains possible.
+ */
+
+import type { BlobStore } from "./raw-cache.types";
+import { blobKeys, deleteBlob, getBlob, putBlob } from "./storage/kv";
+
+/**
+ * Whether this host can back the cache at all.
+ *
+ * Always true where the app runs -- IndexedDB is what presets, settings and
+ * run history already depend on -- but the caller reads better for asking,
+ * and a host without it degrades to converting every time rather than
+ * throwing.
+ */
+export function blobStoreAvailable(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+export function idbBlobStore(): BlobStore {
+  return {
+    keys: () => blobKeys(),
+    read: (key) => getBlob(key),
+    remove: async (key) => {
+      await deleteBlob(key);
+    },
+    write: async (key, bytes) => {
+      await putBlob(key, bytes);
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx jest src/lib/raw-cache-idb.test.ts && npm test && npx tsc --noEmit && npm run check`
+Expected: PASS, six new tests, no regressions, no type or lint errors.
+
+**Check the version bump did not break existing data.** `src/lib/storage/migrate-tauri-files.ts` and the preset tests exercise the same database; confirm they still pass, since a botched `onupgradeneeded` would lose a user's presets rather than fail loudly.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/raw-cache-opfs.ts
-git commit -m "feat(raw): back the persistent cache with OPFS
+git add src/lib/raw-cache-idb.ts src/lib/raw-cache-idb.test.ts src/lib/storage/kv.ts
+git commit -m "feat(raw): back the persistent cache with IndexedDB
 
-createWritable rather than createSyncAccessHandle: the sync handle locks the
-file for its lifetime and a lock held across an await deadlocks. Conversions
-are already serialised, so the throughput difference never reaches the user."
+#243 specified OPFS. The probe found navigator.storage.getDirectory absent in
+WebKit and in WebKitGTK 605.1.15, the webview Tauri uses on Linux -- not slow,
+not quota-limited, absent. An OPFS cache would have silently never worked for
+Safari or Linux desktop users. IndexedDB round-tripped 67 MB everywhere."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
+++ b/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
@@ -1,0 +1,1615 @@
+# Persistent RAW-to-TIFF Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make RAW-to-TIFF conversions survive a page reload, so a 10-frame CR2 bracket costs ~19 s of demosaic once rather than on every visit.
+
+**Architecture:** A persistent tier sits behind the existing in-memory session tier, inside the RAW worker (`src/lib/raw-worker.ts`). The worker already holds the source bytes, so it hashes them, looks the hash up in a content-addressed blob store, and converts only on a miss. Blobs live in OPFS (or IndexedDB — Task 1 decides); a small index in IndexedDB carries sizes and last-used stamps, because OPFS exposes no access time and LRU eviction is unimplementable without it.
+
+**Tech Stack:** TypeScript, Next.js static export, Web Workers, OPFS (`navigator.storage.getDirectory`), IndexedDB, Jest + jsdom for unit tests, Playwright (`e2e-web`) and WebdriverIO (`e2e-tests`) for browser and desktop.
+
+**Design doc:** `docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md`
+**Issue:** [#243](https://github.com/radiantlab/LumiLab/issues/243)
+
+## Global Constraints
+
+- **Budget: 2 GB**, fixed, for the persistent tier. Constant `BUDGET_BYTES = 2 * 1024 * 1024 * 1024`.
+- **The cache may never be the reason a conversion fails.** A read failure is a miss; a write failure is logged and swallowed.
+- **The session tier is untouched.** `src/lib/raw-preview.ts`, its 768 MB budget and its `path|size:mtime` key do not change.
+- **`dcrawArgs` stays the single flag set.** Do not add a second, faster set for previews.
+- **The cache write must precede the `postMessage` transfer.** Transferring detaches the buffer; caching afterwards persists a zero-byte file. This is the failure already fixed in `93ba5fc`.
+- **The worker must resolve `versions.json` from the absolute `request.wasmBaseUrl`**, never a relative `/wasm`, which in a worker resolves against the worker's own chunk.
+- **Never import `src/lib/presets.ts` from worker code.** It pulls in a React config provider. That is why Task 2 exists.
+- Lint with `npm run check`; fix with `npm run fix`. Unit tests: `npm test`.
+
+## File Structure
+
+**Create:**
+
+| File | Responsibility |
+|---|---|
+| `src/lib/hash.ts` | `sha256Hex`, extracted so worker code can hash without importing preset machinery. |
+| `src/lib/raw-cache.types.ts` | `BlobStore`, `CacheEntry`, `CacheIndex`. Importable without an implementation. |
+| `src/lib/raw-cache.ts` | The tier: get, put, eviction, index, sweep, usage, clear. Storage injected. |
+| `src/lib/raw-cache-key.ts` | Content hash + tool tag. Separate from storage because it is derivation, not I/O. |
+| `src/lib/raw-cache-opfs.ts` | `opfsBlobStore()`. The only file that touches OPFS. |
+| `e2e-web/tests/storage-probe.spec.ts` | Task 1's compatibility probe. |
+
+> **Deviation from the spec, noted deliberately:** the design's component table lists three new files; this plan has four, splitting key derivation (`raw-cache-key.ts`) from storage (`raw-cache.ts`). They have different dependencies — the key needs `dcrawArgs` and `versions.json`, the store needs IndexedDB — and mixing them would make the cache untestable without stubbing a fetch.
+
+**Modify:**
+
+- `src/lib/presets.ts` — re-export `sha256Hex` from `hash.ts` (Task 2).
+- `src/lib/storage/kv.ts` — add `updateDocument` (Task 3).
+- `src/lib/raw-worker.ts` — consult and populate the cache (Task 8).
+- `src/app/settings-page/page.tsx` — usage read-out and Clear button (Task 9).
+- `e2e-web/tests/perf.bench.ts` — reload-survival measurement (Task 10).
+
+---
+
+### Task 1: Probe OPFS and IndexedDB across hosts
+
+Gates the backend choice. Produces a compatibility table, not a feature. **Do not start Task 7 until this is recorded.**
+
+**Files:**
+- Create: `e2e-web/tests/storage-probe.spec.ts`
+- Modify: `docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md` (record results)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a decision — approach **A** (OPFS blobs) or **B** (IndexedDB blobs) — which Task 7 implements.
+
+- [ ] **Step 1: Write the probe**
+
+```ts
+// e2e-web/tests/storage-probe.spec.ts
+/**
+ * Answers #243's open question: does OPFS work where this app runs?
+ *
+ * Not a regression test. It reports a table and asserts only that the browser
+ * did not lie -- bytes written must read back identical. Run it once per host
+ * and record the result in the design doc; it decides whether the persistent
+ * cache stores blobs in OPFS or in IndexedDB.
+ */
+import { expect, test } from "@playwright/test";
+
+/** One converted CR2 frame, near enough. The realistic unit, not a token blob. */
+const BLOB_BYTES = 67 * 1024 * 1024;
+
+test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
+  page,
+}) => {
+  await page.goto("/home-page");
+
+  const report = await page.evaluate(async (size) => {
+    const out: Record<string, unknown> = {};
+
+    const estimate = await navigator.storage?.estimate?.();
+    out.quota = estimate?.quota ?? null;
+    out.usage = estimate?.usage ?? null;
+
+    // A recognisable, non-uniform pattern: a run of zeroes would survive a
+    // truncated write and still compare equal.
+    const source = new Uint8Array(size);
+    for (let i = 0; i < size; i += 4096) {
+      source[i] = (i / 4096) % 251;
+    }
+
+    out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
+    if (out.opfsAvailable) {
+      try {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle("probe.bin", { create: true });
+        const writable = await handle.createWritable();
+        const started = performance.now();
+        await writable.write(source);
+        await writable.close();
+        out.opfsWriteMs = Math.round(performance.now() - started);
+
+        const readStarted = performance.now();
+        const back = new Uint8Array(await (await handle.getFile()).arrayBuffer());
+        out.opfsReadMs = Math.round(performance.now() - readStarted);
+        out.opfsRoundTrips =
+          back.length === source.length &&
+          back[0] === source[0] &&
+          back[size - 4096] === source[size - 4096];
+
+        await root.removeEntry("probe.bin");
+        out.opfsRemoved = true;
+      } catch (error) {
+        out.opfsError = String(error);
+      }
+    }
+
+    try {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open("probe-db", 1);
+        request.onupgradeneeded = () => request.result.createObjectStore("blobs");
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const started = performance.now();
+      await new Promise<void>((resolve, reject) => {
+        const transaction = database.transaction("blobs", "readwrite");
+        transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error);
+      });
+      out.idbWriteMs = Math.round(performance.now() - started);
+      out.idbRoundTrips = true;
+      database.close();
+      indexedDB.deleteDatabase("probe-db");
+    } catch (error) {
+      out.idbError = String(error);
+    }
+
+    return out;
+  }, BLOB_BYTES);
+
+  process.stdout.write(
+    `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
+  );
+
+  // The only real assertion: a backend that reports success must not corrupt.
+  if (report.opfsAvailable && !report.opfsError) {
+    expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
+  }
+});
+```
+
+- [ ] **Step 2: Run it in both browser engines**
+
+```bash
+npm run build
+npm --prefix e2e-web exec playwright test tests/storage-probe.spec.ts --project=webkit
+npm --prefix e2e-web exec playwright test tests/storage-probe.spec.ts --project=chromium
+```
+
+Expected: PASS on both, with a `===STORAGE_PROBE===` block printed. WebKit is the one to watch — Safari has a history of OPFS write bugs.
+
+- [ ] **Step 3: Run it on the desktop hosts**
+
+The desktop suite is WebdriverIO, not Playwright. Port the `page.evaluate` body into a `browser.execute` call in a new `e2e-tests/test/specs/storage-probe.e2e.ts`, following the structure of `e2e-tests/test/specs/app.e2e.ts`. Run locally for WKWebView:
+
+```bash
+npm run test:e2e:desktop
+```
+
+For WebView2 (Windows) and WebKitGTK (Linux), push the branch and read the `e2e-tests` job output in CI, which already runs all three platforms.
+
+- [ ] **Step 4: Record the results and decide**
+
+Add a "Probe results" section to the design doc with a row per host: `opfsAvailable`, `opfsRoundTrips`, `opfsWriteMs`, `quota`, `idbWriteMs`, and any error strings.
+
+Decision rule, stated in advance so the result is not rationalised after the fact:
+- OPFS round-trips correctly on **all four** engines (WebKit, Chromium, WKWebView, WebView2, WebKitGTK) → **approach A**.
+- OPFS fails or corrupts on **any** engine → **approach B**, and note which.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-web/tests/storage-probe.spec.ts e2e-tests/test/specs/storage-probe.e2e.ts docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+git commit -m "test(storage): probe OPFS and IndexedDB across every host
+
+#243 assumes OPFS works in the three Tauri webviews and in Safari. Nothing in
+the codebase uses OPFS today, so that was an assumption rather than a finding.
+This records what each engine actually does with a converted-frame-sized blob."
+```
+
+---
+
+### Task 2: Extract `sha256Hex` so worker code can hash
+
+**Files:**
+- Create: `src/lib/hash.ts`, `src/lib/hash.test.ts`
+- Modify: `src/lib/presets.ts:79-85`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `sha256Hex(bytes: Uint8Array): Promise<string>` — lowercase hex, 64 chars.
+
+Why: `presets.ts` imports `pipelineConfig` from a React config provider, so importing it into a worker would drag React into the worker bundle.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/hash.test.ts
+import { sha256Hex } from "./hash";
+
+describe("sha256Hex", () => {
+  it("returns the known digest of the empty input", async () => {
+    expect(await sha256Hex(new Uint8Array())).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+
+  it("returns 64 lowercase hex characters", async () => {
+    const digest = await sha256Hex(new Uint8Array([1, 2, 3]));
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("distinguishes different bytes", async () => {
+    expect(await sha256Hex(new Uint8Array([1]))).not.toBe(
+      await sha256Hex(new Uint8Array([2]))
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx jest src/lib/hash.test.ts`
+Expected: FAIL — `Cannot find module './hash'`.
+
+- [ ] **Step 3: Create the module**
+
+```ts
+// src/lib/hash.ts
+/**
+ * Content hashing, in its own module so a worker can use it.
+ *
+ * This lived in `presets.ts`, which imports a React config provider. Importing
+ * that into `raw-worker.ts` would pull React into the worker bundle for the
+ * sake of one twelve-line function.
+ */
+
+/** Lowercase hex SHA-256. `crypto.subtle` is polyfilled for tests in jest.setup.js. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+```
+
+- [ ] **Step 4: Point `presets.ts` at it**
+
+In `src/lib/presets.ts`, delete the `sha256Hex` function body and add to the imports:
+
+```ts
+import { sha256Hex } from "./hash";
+```
+
+Then re-export it, because other modules import it from here:
+
+```ts
+export { sha256Hex };
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test`
+Expected: PASS, including the existing preset tests. If anything imported `sha256Hex` from `presets.ts`, the re-export keeps it working.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/hash.ts src/lib/hash.test.ts src/lib/presets.ts
+git commit -m "refactor: extract sha256Hex so worker code can hash
+
+presets.ts imports a React config provider, so a worker importing it for one
+hash function would pull React into the worker bundle."
+```
+
+---
+
+### Task 3: Atomic read-modify-write for documents
+
+**Files:**
+- Modify: `src/lib/storage/kv.ts`
+- Test: `src/lib/storage/kv.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `updateDocument<T>(key: string, change: (current: T | undefined) => T): Promise<T>` — reads, applies `change`, writes, all inside one IndexedDB transaction, and returns the written value.
+
+Why: the cache index is a read-modify-write. `run()` puts one request per transaction, so a get-then-put via two calls can interleave with the Settings "Clear" action and lose an update.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/storage/kv.test.ts
+import { getDocument, putDocument, updateDocument } from "./kv";
+
+describe("updateDocument", () => {
+  it("creates a document when none exists", async () => {
+    const written = await updateDocument<number[]>("counter-a", (current) => [
+      ...(current ?? []),
+      1,
+    ]);
+    expect(written).toEqual([1]);
+    expect(await getDocument<number[]>("counter-a")).toEqual([1]);
+  });
+
+  it("applies the change to the stored value", async () => {
+    await putDocument("counter-b", [1, 2]);
+    const written = await updateDocument<number[]>("counter-b", (current) => [
+      ...(current ?? []),
+      3,
+    ]);
+    expect(written).toEqual([1, 2, 3]);
+  });
+
+  it("does not lose concurrent updates", async () => {
+    await putDocument("counter-c", []);
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((value) =>
+        updateDocument<number[]>("counter-c", (current) => [
+          ...(current ?? []),
+          value,
+        ])
+      )
+    );
+    const stored = await getDocument<number[]>("counter-c");
+    expect(stored).toHaveLength(5);
+  });
+});
+```
+
+Note: `jest.config.js` uses jsdom, which has no IndexedDB. Add `fake-indexeddb` as a devDependency and import it at the top of this test file:
+
+```bash
+npm install --save-dev fake-indexeddb
+```
+
+```ts
+import "fake-indexeddb/auto";
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx jest src/lib/storage/kv.test.ts`
+Expected: FAIL — `updateDocument is not a function`.
+
+- [ ] **Step 3: Implement it**
+
+Add to `src/lib/storage/kv.ts`, below `deleteDocument`:
+
+```ts
+/**
+ * Reads, changes and writes a document inside one transaction.
+ *
+ * `run()` issues a single request per transaction, so `getDocument` followed
+ * by `putDocument` is two transactions with a window between them. The RAW
+ * cache index is written by the worker on every conversion and cleared from
+ * the settings page, and a lost update there means a leaked blob nothing will
+ * ever evict.
+ */
+export function updateDocument<T>(
+  key: string,
+  change: (current: T | undefined) => T
+): Promise<T> {
+  return open().then(
+    (database) =>
+      new Promise<T>((resolve, reject) => {
+        const transaction = database.transaction(DOCUMENTS, "readwrite");
+        const store = transaction.objectStore(DOCUMENTS);
+        const read = store.get(key);
+        let written: T;
+        read.onsuccess = () => {
+          written = change(read.result as T | undefined);
+          store.put(written, key);
+        };
+        read.onerror = () =>
+          reject(read.error ?? new Error(`${DOCUMENTS}: read failed`));
+        // Resolved on the transaction, not the put: the write is only durable
+        // once the transaction commits, and a quota abort can follow a
+        // successful request.
+        transaction.oncomplete = () => resolve(written);
+        transaction.onabort = () =>
+          reject(transaction.error ?? new Error(`${DOCUMENTS}: aborted`));
+      })
+  );
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `npx jest src/lib/storage/kv.test.ts`
+Expected: PASS, all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/storage/kv.ts src/lib/storage/kv.test.ts package.json package-lock.json
+git commit -m "feat(storage): add updateDocument for atomic read-modify-write
+
+The RAW cache index is written by the worker on every conversion and cleared
+from the settings page. Two transactions leave a window where one loses the
+other's update, and a lost index entry is a blob nothing will evict."
+```
+
+---
+
+### Task 4: The cache types and core get/put
+
+**Files:**
+- Create: `src/lib/raw-cache.types.ts`, `src/lib/raw-cache.ts`, `src/lib/raw-cache.test.ts`
+
+**Interfaces:**
+- Consumes: `updateDocument`, `getDocument` (Task 3).
+- Produces:
+  - `interface BlobStore { read(key): Promise<Uint8Array | undefined>; write(key, bytes): Promise<void>; remove(key): Promise<void>; keys(): Promise<string[]> }`
+  - `interface CacheEntry { size: number; lastUsed: number }`
+  - `type CacheIndex = Record<string, CacheEntry>`
+  - `createRawCache(options: RawCacheOptions): RawCache`
+  - `interface RawCache { get(key): Promise<Uint8Array | undefined>; put(key, bytes): Promise<void>; usage(): Promise<number>; clear(): Promise<void> }`
+  - `BUDGET_BYTES: number`
+
+- [ ] **Step 1: Write the types**
+
+```ts
+// src/lib/raw-cache.types.ts
+/**
+ * The persistent RAW cache's storage seam.
+ *
+ * In its own module so `raw-worker.ts` and the settings page can name these
+ * types without importing an implementation -- and so the OPFS implementation
+ * is never pulled into a Jest run, where `navigator.storage` does not exist.
+ */
+
+/** Somewhere large binary blobs live, addressed by key. */
+export interface BlobStore {
+  read(key: string): Promise<Uint8Array | undefined>;
+  write(key: string, bytes: Uint8Array): Promise<void>;
+  remove(key: string): Promise<void>;
+  /** Every key present. Reconciliation only; not a hot path. */
+  keys(): Promise<string[]>;
+}
+
+export interface CacheEntry {
+  size: number;
+  /** Epoch milliseconds. Eviction is least-recently-*used*, not oldest. */
+  lastUsed: number;
+}
+
+/** key -> entry. About 30 entries at a 2 GB budget, so one document holds it. */
+export type CacheIndex = Record<string, CacheEntry>;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// src/lib/raw-cache.test.ts
+import "fake-indexeddb/auto";
+import { BUDGET_BYTES, createRawCache } from "./raw-cache";
+import type { BlobStore } from "./raw-cache.types";
+
+function fakeStore(): BlobStore & { blobs: Map<string, Uint8Array> } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    blobs,
+    keys: () => Promise.resolve(Array.from(blobs.keys())),
+    read: (key) => Promise.resolve(blobs.get(key)),
+    remove: (key) => {
+      blobs.delete(key);
+      return Promise.resolve();
+    },
+    write: (key, bytes) => {
+      blobs.set(key, bytes);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A distinct clock, so "least recently used" is decided rather than raced. */
+function clock() {
+  let time = 1000;
+  return () => {
+    time += 1000;
+    return time;
+  };
+}
+
+describe("the persistent RAW cache", () => {
+  it("returns undefined for a key it has never seen", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    expect(await cache.get("absent")).toBeUndefined();
+  });
+
+  it("returns what was put", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    await cache.put("a", new Uint8Array([1, 2, 3]));
+    expect(Array.from((await cache.get("a")) ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("reports usage as the sum of stored sizes", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    await cache.put("a", new Uint8Array(10));
+    await cache.put("b", new Uint8Array(15));
+    expect(await cache.usage()).toBe(25);
+  });
+
+  it("evicts least recently used first when over budget", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 30, now: clock(), store });
+
+    await cache.put("old", new Uint8Array(10));
+    await cache.put("mid", new Uint8Array(10));
+    await cache.get("old"); // touches "old", making "mid" the oldest use
+    await cache.put("new", new Uint8Array(15));
+
+    expect(store.blobs.has("mid")).toBe(false);
+    expect(store.blobs.has("old")).toBe(true);
+    expect(store.blobs.has("new")).toBe(true);
+  });
+
+  it("never evicts the entry just added", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 20, now: clock(), store });
+    await cache.put("a", new Uint8Array(20));
+    await cache.put("b", new Uint8Array(20));
+    expect(store.blobs.has("b")).toBe(true);
+  });
+
+  it("refuses a blob larger than the whole budget", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 10, now: clock(), store });
+    await cache.put("huge", new Uint8Array(11));
+    expect(store.blobs.has("huge")).toBe(false);
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("clears every blob and resets usage", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("a", new Uint8Array(10));
+    await cache.clear();
+    expect(store.blobs.size).toBe(0);
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("defaults to a 2 GB budget", () => {
+    expect(BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
+  });
+});
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+Run: `npx jest src/lib/raw-cache.test.ts`
+Expected: FAIL — `Cannot find module './raw-cache'`.
+
+- [ ] **Step 4: Implement**
+
+```ts
+// src/lib/raw-cache.ts
+/**
+ * The persistent tier of the RAW-to-TIFF cache.
+ *
+ * Sits behind the session tier in `raw-preview.ts` and in front of conversion.
+ * Content-addressed, so a file that moved is still a hit and a file that
+ * changed is not -- which is a correctness requirement rather than a nicety in
+ * the browser, where `registerSessionFile` mints `/session/<n>/<name>` from a
+ * counter that restarts each session and therefore names different bytes with
+ * the same string across visits.
+ *
+ * Storage is injected. OPFS is the intended backing (`raw-cache-opfs.ts`), but
+ * this module never names it: the eviction and index logic is the part worth
+ * testing, and `navigator.storage` does not exist under Jest.
+ *
+ * The index is a single document rather than a row per entry. At a 2 GB budget
+ * and ~67 MB per converted frame that is about thirty entries, so one document
+ * is small, updates atomically, and can be read straight from the page for the
+ * settings read-out without involving the worker.
+ */
+
+import { getDocument, updateDocument } from "./storage/kv";
+import type { BlobStore, CacheEntry, CacheIndex } from "./raw-cache.types";
+
+const INDEX_KEY = "raw-cache-index";
+
+/** See the design doc. Fixed rather than a share of the origin quota. */
+export const BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
+
+export interface RawCacheOptions {
+  store: BlobStore;
+  budgetBytes?: number;
+  /** Injected so eviction order is decided in tests rather than raced. */
+  now?: () => number;
+}
+
+export interface RawCache {
+  get(key: string): Promise<Uint8Array | undefined>;
+  put(key: string, bytes: Uint8Array): Promise<void>;
+  usage(): Promise<number>;
+  clear(): Promise<void>;
+}
+
+export function createRawCache(options: RawCacheOptions): RawCache {
+  const { store } = options;
+  const budget = options.budgetBytes ?? BUDGET_BYTES;
+  const now = options.now ?? (() => Date.now());
+
+  async function readIndex(): Promise<CacheIndex> {
+    return (await getDocument<CacheIndex>(INDEX_KEY)) ?? {};
+  }
+
+  async function get(key: string): Promise<Uint8Array | undefined> {
+    const index = await readIndex();
+    if (!index[key]) {
+      return;
+    }
+
+    const bytes = await store.read(key).catch(() => undefined);
+    if (!bytes) {
+      // Phantom: the index remembers a blob the store no longer has, which is
+      // what a browser reclaiming storage under quota pressure leaves behind.
+      // Dropping the entry turns it into an ordinary miss.
+      await updateIndex((current) => {
+        delete current[key];
+        return current;
+      });
+      return;
+    }
+
+    await updateIndex((current) => {
+      const entry = current[key];
+      if (entry) {
+        entry.lastUsed = now();
+      }
+      return current;
+    });
+    return bytes;
+  }
+
+  async function put(key: string, bytes: Uint8Array): Promise<void> {
+    // A blob bigger than the whole budget would evict everything and then
+    // itself, so it is never stored at all.
+    if (bytes.byteLength > budget) {
+      return;
+    }
+
+    // Blob first, index second. An interrupted write then leaves an orphan,
+    // which `sweep` reclaims, rather than a phantom the next reader must
+    // discover.
+    await store.write(key, bytes);
+
+    const evicted: string[] = [];
+    await updateIndex((current) => {
+      current[key] = { lastUsed: now(), size: bytes.byteLength };
+      let total = Object.values(current).reduce(
+        (sum, entry) => sum + entry.size,
+        0
+      );
+      const order = Object.entries(current)
+        .filter(([candidate]) => candidate !== key)
+        .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
+      for (const [candidate, entry] of order) {
+        if (total <= budget) {
+          break;
+        }
+        delete current[candidate];
+        total -= entry.size;
+        evicted.push(candidate);
+      }
+      return current;
+    });
+
+    // Outside the index update: a failed removal must not roll back an index
+    // that is already correct. What it leaves is an orphan, which sweeps.
+    await Promise.all(
+      evicted.map((candidate) => store.remove(candidate).catch(() => undefined))
+    );
+  }
+
+  async function usage(): Promise<number> {
+    const index = await readIndex();
+    return Object.values(index).reduce((sum, entry) => sum + entry.size, 0);
+  }
+
+  async function clear(): Promise<void> {
+    const present = await store.keys().catch(() => [] as string[]);
+    await Promise.all(
+      present.map((key) => store.remove(key).catch(() => undefined))
+    );
+    await updateIndex(() => ({}));
+  }
+
+  return { clear, get, put, usage };
+}
+
+function updateIndex(
+  change: (current: CacheIndex) => CacheIndex
+): Promise<CacheIndex> {
+  return updateDocument<CacheIndex>(INDEX_KEY, (current) =>
+    change(current ?? {})
+  );
+}
+
+export type { BlobStore, CacheEntry, CacheIndex };
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx jest src/lib/raw-cache.test.ts`
+Expected: PASS, all eight.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/raw-cache.ts src/lib/raw-cache.types.ts src/lib/raw-cache.test.ts
+git commit -m "feat(raw): add the persistent cache tier, storage injected
+
+Content-addressed with an LRU bound. Storage is a seam rather than OPFS
+directly: the eviction and index logic is the part worth testing, and
+navigator.storage does not exist under Jest."
+```
+
+---
+
+### Task 5: Reconciliation — orphan sweep
+
+Task 4 already self-heals phantoms. This adds the other half.
+
+**Files:**
+- Modify: `src/lib/raw-cache.ts`, `src/lib/raw-cache.test.ts`
+
+**Interfaces:**
+- Consumes: `createRawCache` (Task 4).
+- Produces: `RawCache.sweep(): Promise<void>`, and `get`/`put` run it lazily once per cache instance.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/raw-cache.test.ts`:
+
+```ts
+describe("reconciliation", () => {
+  it("reports a miss and forgets the entry when the blob has vanished", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("a", new Uint8Array(10));
+
+    store.blobs.delete("a"); // as a browser reclaiming storage would
+
+    expect(await cache.get("a")).toBeUndefined();
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("deletes blobs the index does not know about", async () => {
+    const store = fakeStore();
+    store.blobs.set("orphan", new Uint8Array(10)); // a crashed write
+
+    const cache = createRawCache({ now: clock(), store });
+    await cache.sweep();
+
+    expect(store.blobs.has("orphan")).toBe(false);
+  });
+
+  it("sweeps once, not on every call", async () => {
+    const store = fakeStore();
+    let listed = 0;
+    const counting = {
+      ...store,
+      keys: () => {
+        listed += 1;
+        return store.keys();
+      },
+    };
+    const cache = createRawCache({ now: clock(), store: counting });
+
+    await cache.get("a");
+    await cache.get("b");
+    await cache.put("c", new Uint8Array(1));
+
+    expect(listed).toBe(1);
+  });
+
+  it("keeps blobs the index does know about", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("kept", new Uint8Array(10));
+
+    await cache.sweep();
+
+    expect(store.blobs.has("kept")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx jest src/lib/raw-cache.test.ts -t reconciliation`
+Expected: FAIL — `cache.sweep is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/raw-cache.ts`, add `sweep` to the interface:
+
+```ts
+export interface RawCache {
+  get(key: string): Promise<Uint8Array | undefined>;
+  put(key: string, bytes: Uint8Array): Promise<void>;
+  usage(): Promise<number>;
+  clear(): Promise<void>;
+  /** Deletes blobs the index does not know about. Runs once per instance. */
+  sweep(): Promise<void>;
+}
+```
+
+Inside `createRawCache`, add:
+
+```ts
+  /**
+   * Blobs with no index entry, deleted.
+   *
+   * A write that landed but whose index update did not is invisible to
+   * eviction, so it would consume disk for the life of the origin. About
+   * thirty keys at this budget, so listing them is cheap.
+   */
+  async function sweep(): Promise<void> {
+    const index = await readIndex();
+    const present = await store.keys().catch(() => [] as string[]);
+    await Promise.all(
+      present
+        .filter((key) => !index[key])
+        .map((key) => store.remove(key).catch(() => undefined))
+    );
+  }
+
+  /** Once per instance: a sweep on every lookup would list the store per frame. */
+  let swept: Promise<void> | undefined;
+  function sweepOnce(): Promise<void> {
+    swept ??= sweep().catch(() => undefined);
+    return swept;
+  }
+```
+
+Then make `get` and `put` await it as their first line:
+
+```ts
+  async function get(key: string): Promise<Uint8Array | undefined> {
+    await sweepOnce();
+    const index = await readIndex();
+    // ...unchanged from here
+```
+
+```ts
+  async function put(key: string, bytes: Uint8Array): Promise<void> {
+    await sweepOnce();
+    if (bytes.byteLength > budget) {
+      return;
+    }
+    // ...unchanged from here
+```
+
+And return it: `return { clear, get, put, sweep, usage };`
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx jest src/lib/raw-cache.test.ts`
+Expected: PASS, all twelve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/raw-cache.ts src/lib/raw-cache.test.ts
+git commit -m "feat(raw): reconcile the cache index against the blob store
+
+Two stores can disagree. A phantom index entry self-heals into a miss on read;
+an orphaned blob is invisible to eviction and would consume disk forever, so it
+is swept once per session."
+```
+
+---
+
+### Task 6: The cache key, including tool identity
+
+**Files:**
+- Create: `src/lib/raw-cache-key.ts`, `src/lib/raw-cache-key.test.ts`
+
+**Interfaces:**
+- Consumes: `sha256Hex` (Task 2), `dcrawArgs` from `./pipeline/stages`.
+- Produces:
+  - `toolTag(wasmBaseUrl: string): Promise<string>` — 12 hex chars, memoised per URL.
+  - `rawCacheKey(bytes: Uint8Array, tag: string): Promise<string>` — `"<64 hex>-<12 hex>"`.
+  - `resetToolTagForTests(): void`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/raw-cache-key.test.ts
+import { rawCacheKey, resetToolTagForTests, toolTag } from "./raw-cache-key";
+
+const VERSIONS = {
+  emscripten: "6.0.4",
+  tools: { dcraw_emu: { commit: "c9d6743", describe: "", repository: "", version: "" } },
+};
+
+function mockFetch(body: unknown) {
+  globalThis.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(body), ok: true })
+  ) as unknown as typeof fetch;
+}
+
+describe("the RAW cache key", () => {
+  beforeEach(() => {
+    resetToolTagForTests();
+  });
+
+  it("joins a content hash and a tool tag", async () => {
+    const key = await rawCacheKey(new Uint8Array([1, 2, 3]), "abc123def456");
+    expect(key).toMatch(/^[0-9a-f]{64}-abc123def456$/);
+  });
+
+  it("gives different keys to different bytes", async () => {
+    expect(await rawCacheKey(new Uint8Array([1]), "t")).not.toBe(
+      await rawCacheKey(new Uint8Array([2]), "t")
+    );
+  });
+
+  it("derives a twelve-character tag from the recorded commit", async () => {
+    mockFetch(VERSIONS);
+    const tag = await toolTag("https://example.test/wasm");
+    expect(tag).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("changes the tag when the dcraw_emu commit changes", async () => {
+    mockFetch(VERSIONS);
+    const before = await toolTag("https://example.test/wasm");
+
+    resetToolTagForTests();
+    mockFetch({ ...VERSIONS, tools: { dcraw_emu: { ...VERSIONS.tools.dcraw_emu, commit: "deadbee" } } });
+    const after = await toolTag("https://example.test/wasm");
+
+    expect(after).not.toBe(before);
+  });
+
+  it("fetches versions.json from the absolute base it is given", async () => {
+    mockFetch(VERSIONS);
+    await toolTag("https://example.test/wasm");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://example.test/wasm/versions.json"
+    );
+  });
+
+  it("asks once per base URL", async () => {
+    mockFetch(VERSIONS);
+    await toolTag("https://example.test/wasm");
+    await toolTag("https://example.test/wasm");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx jest src/lib/raw-cache-key.test.ts`
+Expected: FAIL — `Cannot find module './raw-cache-key'`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/lib/raw-cache-key.ts
+/**
+ * What names a cached conversion.
+ *
+ * Two parts, and the second is the one that is easy to leave out:
+ *
+ *  - **The content hash.** Not the path. `registerSessionFile` mints
+ *    `/session/<n>/<name>` from a counter that restarts each session, so the
+ *    same path names different bytes across visits and a path-keyed cache
+ *    would serve the wrong image.
+ *  - **A tool tag**, derived from the `dcraw_emu` commit the wasm was built
+ *    from and the flags it is run with. Without it, rebuilding the artifacts
+ *    (#244 automates exactly that) would serve pixels produced by a different
+ *    demosaic while reporting success -- undoing the byte-identical guarantee
+ *    `raw-preview.ts` exists to hold.
+ *
+ * Folded into the key rather than checked on read, so a tool change simply
+ * misses, stale entries age out by LRU, and a rollback re-hits its own entries
+ * instead of having discarded them.
+ */
+
+import { sha256Hex } from "./hash";
+import { dcrawArgs } from "./pipeline/stages";
+
+interface VersionsDocument {
+  tools?: Record<string, { commit?: string } | undefined>;
+}
+
+/** Memoised per base URL: the file describes committed artifacts. */
+const tags = new Map<string, Promise<string>>();
+
+/**
+ * Identity of the converter, as twelve hex characters.
+ *
+ * `build-versions.ts` is not reused here because it hardcodes a relative
+ * `/wasm`, and in a worker a relative URL resolves against the worker's own
+ * chunk rather than the document. The absolute base is passed in instead.
+ */
+export function toolTag(wasmBaseUrl: string): Promise<string> {
+  const cached = tags.get(wasmBaseUrl);
+  if (cached) {
+    return cached;
+  }
+  const deriving = derive(wasmBaseUrl).catch((error: unknown) => {
+    // Not remembered, so a transient fetch failure does not pin an
+    // "unknown" tag for the life of the worker.
+    tags.delete(wasmBaseUrl);
+    throw error;
+  });
+  tags.set(wasmBaseUrl, deriving);
+  return deriving;
+}
+
+async function derive(wasmBaseUrl: string): Promise<string> {
+  const response = await fetch(`${wasmBaseUrl}/versions.json`);
+  if (!response.ok) {
+    throw new Error(
+      `${wasmBaseUrl}/versions.json returned ${response.status}`
+    );
+  }
+  const versions = (await response.json()) as VersionsDocument;
+  const commit = versions.tools?.dcraw_emu?.commit ?? "unknown";
+  // Placeholder paths, so the tag tracks the flags and does not vary per frame.
+  const args = dcrawArgs("in", "out").join(" ");
+  const digest = await sha256Hex(
+    new TextEncoder().encode(`${commit} ${args}`)
+  );
+  return digest.slice(0, 12);
+}
+
+/** `<content hash>-<tool tag>`. */
+export async function rawCacheKey(
+  bytes: Uint8Array,
+  tag: string
+): Promise<string> {
+  return `${await sha256Hex(bytes)}-${tag}`;
+}
+
+export function resetToolTagForTests(): void {
+  tags.clear();
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx jest src/lib/raw-cache-key.test.ts`
+Expected: PASS, all six.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/raw-cache-key.ts src/lib/raw-cache-key.test.ts
+git commit -m "feat(raw): derive the cache key from content and tool identity
+
+The content hash is required for correctness in a browser, where session paths
+restart from a counter and name different bytes across visits. The tool tag
+stops a rebuilt dcraw_emu from silently serving the previous demosaic."
+```
+
+---
+
+### Task 7: The blob store implementation
+
+**Run Task 1 first.** Implement whichever approach the probe chose. The steps below are approach **A** (OPFS); if the probe chose **B**, create `src/lib/raw-cache-idb.ts` exporting `idbBlobStore()` with the same `BlobStore` shape, backed by a new `blobs` object store in `kv.ts`, and adapt the commit message.
+
+**Files:**
+- Create: `src/lib/raw-cache-opfs.ts`
+- Test: covered by Task 1's probe and Task 10's end-to-end; not unit-tested, because jsdom has no OPFS and a mock of it would assert only that the mock works.
+
+**Interfaces:**
+- Consumes: `BlobStore` (Task 4).
+- Produces: `opfsBlobStore(directoryName?: string): BlobStore`, `opfsAvailable(): boolean`.
+
+- [ ] **Step 1: Implement**
+
+```ts
+// src/lib/raw-cache-opfs.ts
+/**
+ * OPFS backing for the persistent RAW cache.
+ *
+ * The only file in the app that touches OPFS, so nothing else has to care
+ * that it exists -- and Jest never imports it, since `navigator.storage` is
+ * absent under jsdom and a mocked OPFS would only prove the mock works. It is
+ * covered by `e2e-web/tests/storage-probe.spec.ts` and by the reload measured
+ * in `perf.bench.ts`.
+ *
+ * Writes go through `createWritable` rather than `createSyncAccessHandle`.
+ * The sync handle is faster and is why this tier had to live in a worker at
+ * all, but it locks the file for the handle's lifetime, and a lock held across
+ * an await is how two callers deadlock. Conversions are already serialised by
+ * `raw-worker-client.ts`, so the throughput difference does not reach the user,
+ * whereas the deadlock would.
+ */
+
+import type { BlobStore } from "./raw-cache.types";
+
+const DIRECTORY = "raw-tiff-cache";
+
+/** Whether this host offers OPFS at all. Checked before a store is built. */
+export function opfsAvailable(): boolean {
+  return typeof navigator !== "undefined" &&
+    typeof navigator.storage?.getDirectory === "function";
+}
+
+export function opfsBlobStore(directoryName = DIRECTORY): BlobStore {
+  let directory: Promise<FileSystemDirectoryHandle> | undefined;
+
+  function open(): Promise<FileSystemDirectoryHandle> {
+    directory ??= navigator.storage
+      .getDirectory()
+      .then((root) => root.getDirectoryHandle(directoryName, { create: true }))
+      .catch((error: unknown) => {
+        // Not remembered: a first failure must not make the cache permanently
+        // unusable for the life of the worker.
+        directory = undefined;
+        throw error;
+      });
+    return directory;
+  }
+
+  return {
+    async keys(): Promise<string[]> {
+      const handle = await open();
+      const found: string[] = [];
+      // `keys()` is an async iterator on the directory handle.
+      for await (const name of (
+        handle as unknown as { keys(): AsyncIterable<string> }
+      ).keys()) {
+        found.push(name);
+      }
+      return found;
+    },
+
+    async read(key: string): Promise<Uint8Array | undefined> {
+      const handle = await open();
+      try {
+        const file = await handle.getFileHandle(key);
+        return new Uint8Array(await (await file.getFile()).arrayBuffer());
+      } catch {
+        // NotFoundError is the ordinary miss, and any other read failure is
+        // treated as one: the caller converts, which is always correct.
+        return;
+      }
+    },
+
+    async remove(key: string): Promise<void> {
+      const handle = await open();
+      await handle.removeEntry(key).catch(() => undefined);
+    },
+
+    async write(key: string, bytes: Uint8Array): Promise<void> {
+      const handle = await open();
+      const file = await handle.getFileHandle(key, { create: true });
+      const writable = await file.createWritable();
+      try {
+        await writable.write(bytes as BufferSource);
+      } finally {
+        // Closed on both paths: an unclosed writable leaves a zero-length file
+        // that later reads as a corrupt hit rather than a miss.
+        await writable.close();
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Verify it type-checks and lints**
+
+Run: `npx tsc --noEmit && npm run check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/raw-cache-opfs.ts
+git commit -m "feat(raw): back the persistent cache with OPFS
+
+createWritable rather than createSyncAccessHandle: the sync handle locks the
+file for its lifetime and a lock held across an await deadlocks. Conversions
+are already serialised, so the throughput difference never reaches the user."
+```
+
+---
+
+### Task 8: Wire the cache into the RAW worker
+
+**Files:**
+- Modify: `src/lib/raw-worker.ts`
+- Test: `src/lib/raw-worker.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `createRawCache` (Task 4), `rawCacheKey`/`toolTag` (Task 6), `opfsBlobStore`/`opfsAvailable` (Task 7).
+- Produces: no new exports. Behaviour: identical bytes convert once across reloads.
+
+- [ ] **Step 1: Write the failing test**
+
+Extract the cache decision into a testable function rather than testing the worker's message plumbing, which needs a real `Worker`.
+
+```ts
+// src/lib/raw-worker.test.ts
+import { convertWithCache } from "./raw-worker";
+import type { RawCache } from "./raw-cache";
+
+function fakeCache(seed: Record<string, Uint8Array> = {}) {
+  const blobs = new Map(Object.entries(seed));
+  const cache: RawCache & { blobs: Map<string, Uint8Array> } = {
+    blobs,
+    clear: () => Promise.resolve(),
+    get: (key) => Promise.resolve(blobs.get(key)),
+    put: (key, bytes) => {
+      blobs.set(key, bytes);
+      return Promise.resolve();
+    },
+    sweep: () => Promise.resolve(),
+    usage: () => Promise.resolve(0),
+  };
+  return cache;
+}
+
+describe("converting with the persistent cache", () => {
+  it("returns the cached TIFF without converting", async () => {
+    const cache = fakeCache({ "key-1": new Uint8Array([9, 9]) });
+    let converted = 0;
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => {
+        converted += 1;
+        return Promise.resolve(new Uint8Array([1]));
+      },
+      key: () => Promise.resolve("key-1"),
+    });
+
+    expect(Array.from(tiff)).toEqual([9, 9]);
+    expect(converted).toBe(0);
+  });
+
+  it("converts and stores on a miss", async () => {
+    const cache = fakeCache();
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([4, 5])),
+      key: () => Promise.resolve("key-2"),
+    });
+
+    expect(Array.from(tiff)).toEqual([4, 5]);
+    expect(Array.from(cache.blobs.get("key-2") ?? [])).toEqual([4, 5]);
+  });
+
+  it("still converts when the key cannot be derived", async () => {
+    const cache = fakeCache();
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([7])),
+      key: () => Promise.reject(new Error("versions.json unreachable")),
+    });
+    expect(Array.from(tiff)).toEqual([7]);
+  });
+
+  it("still returns the TIFF when the cache write fails", async () => {
+    const cache = fakeCache();
+    cache.put = () => Promise.reject(new Error("quota exceeded"));
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([8])),
+      key: () => Promise.resolve("key-3"),
+    });
+    expect(Array.from(tiff)).toEqual([8]);
+  });
+
+  it("still returns the TIFF when the cache read fails", async () => {
+    const cache = fakeCache();
+    cache.get = () => Promise.reject(new Error("storage unavailable"));
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([6])),
+      key: () => Promise.resolve("key-4"),
+    });
+    expect(Array.from(tiff)).toEqual([6]);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx jest src/lib/raw-worker.test.ts`
+Expected: FAIL — `convertWithCache is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/raw-worker.ts`, add the imports:
+
+```ts
+import { createRawCache, type RawCache } from "./raw-cache";
+import { rawCacheKey, toolTag } from "./raw-cache-key";
+import { opfsAvailable, opfsBlobStore } from "./raw-cache-opfs";
+```
+
+Add the cache accessor beside `runnerFor`:
+
+```ts
+let cache: RawCache | undefined;
+
+/**
+ * The persistent tier, or nothing on a host without OPFS.
+ *
+ * Absence is not an error: the conversion path is unchanged and only slower,
+ * which is exactly what every host did before this existed.
+ */
+function cacheFor(): RawCache | undefined {
+  if (!opfsAvailable()) {
+    return;
+  }
+  cache ??= createRawCache({ store: opfsBlobStore() });
+  return cache;
+}
+```
+
+Add the testable decision function:
+
+```ts
+export interface CachedConversion {
+  cache: RawCache | undefined;
+  convert: () => Promise<Uint8Array>;
+  key: () => Promise<string>;
+}
+
+/**
+ * A conversion, answered from the cache where possible.
+ *
+ * Exported for tests: the worker's own message plumbing needs a real `Worker`,
+ * whereas this is the part with the decisions in it.
+ *
+ * Every cache failure falls through to conversion. The cache may never be the
+ * reason a frame fails to convert -- a read error is a miss, and a write error
+ * is a slower next session rather than a lost image.
+ */
+export async function convertWithCache({
+  cache: tier,
+  convert,
+  key,
+}: CachedConversion): Promise<Uint8Array> {
+  let resolved: string | undefined;
+  if (tier) {
+    try {
+      resolved = await key();
+      const hit = await tier.get(resolved);
+      if (hit) {
+        return hit;
+      }
+    } catch {
+      // Unusable cache: convert, exactly as a host without one does.
+      resolved = undefined;
+    }
+  }
+
+  const tiff = await convert();
+
+  if (tier && resolved) {
+    // Before the caller transfers it. `postMessage` with a transfer detaches
+    // the buffer, and writing afterwards would persist a zero-byte file that
+    // later reads as a corrupt hit -- the failure fixed in 93ba5fc.
+    await tier.put(resolved, tiff).catch(() => undefined);
+  }
+
+  return tiff;
+}
+```
+
+Replace the body of `convert`:
+
+```ts
+async function convert(request: RawConvertRequest): Promise<Uint8Array> {
+  const active = runnerFor(request.wasmBaseUrl);
+  try {
+    return await convertWithCache({
+      cache: cacheFor(),
+      convert: () => convertRaw(active, request.path, request.bytes),
+      key: async () =>
+        rawCacheKey(request.bytes, await toolTag(request.wasmBaseUrl)),
+    });
+  } finally {
+    // Between frames rather than at the end: the runner survives to keep its
+    // compiled modules, so its staged bytes must not survive with it.
+    active.clear();
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx jest src/lib/raw-worker.test.ts && npm test`
+Expected: PASS. The existing `raw-worker-client.test.ts` and `raw-convert.test.ts` must stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/raw-worker.ts src/lib/raw-worker.test.ts
+git commit -m "feat(raw): answer conversions from the persistent cache
+
+The cache is consulted before converting and populated after, always before
+the caller transfers the buffer: postMessage detaches it, and a write after
+that persists a zero-byte file. Every cache failure falls through to
+conversion, so the cache can never be why a frame fails."
+```
+
+---
+
+### Task 9: Report and clear the cache from Settings
+
+**Files:**
+- Modify: `src/app/settings-page/page.tsx`
+
+**Interfaces:**
+- Consumes: `createRawCache`, `BUDGET_BYTES` (Task 4), `opfsAvailable`/`opfsBlobStore` (Task 7).
+- Produces: no exports.
+
+- [ ] **Step 1: Add the state and loader**
+
+In `src/app/settings-page/page.tsx`, add imports:
+
+```ts
+import prettyBytes from "pretty-bytes";
+import { BUDGET_BYTES, createRawCache } from "@/lib/raw-cache";
+import { opfsAvailable, opfsBlobStore } from "@/lib/raw-cache-opfs";
+```
+
+Inside `SettingsPage`, beside the other `useState` calls:
+
+```ts
+  const [cacheBytes, setCacheBytes] = useState<number | null>(null);
+```
+
+In the existing mount `useEffect`, after the `wasmVersions()` block:
+
+```ts
+    // Absent on a host without OPFS, where there is no persistent tier to
+    // report. Zero would claim an empty cache rather than no cache.
+    if (opfsAvailable()) {
+      createRawCache({ store: opfsBlobStore() })
+        .usage()
+        .then(setCacheBytes)
+        .catch(() => setCacheBytes(null));
+    }
+```
+
+- [ ] **Step 2: Add the handler**
+
+Beside `handleUpdatePath`:
+
+```ts
+  /** Empties the persistent RAW cache and re-reads its size. */
+  const handleClearCache = async () => {
+    const cache = createRawCache({ store: opfsBlobStore() });
+    try {
+      await cache.clear();
+      setCacheBytes(await cache.usage());
+      toast.success("RAW conversion cache cleared");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not clear the cache"
+      );
+    }
+  };
+```
+
+- [ ] **Step 3: Render the row**
+
+Add beside the tool-versions block, following the markup already used there:
+
+```tsx
+        {cacheBytes !== null && (
+          <div className="flex items-center justify-between gap-4 py-2">
+            <div>
+              <p className="font-medium text-sm">RAW conversion cache</p>
+              <p className="text-muted-foreground text-xs">
+                {prettyBytes(cacheBytes)} of {prettyBytes(BUDGET_BYTES)} used.
+                Converted frames are reused instead of demosaiced again.
+              </p>
+            </div>
+            <button
+              className="rounded-md border px-3 py-1.5 text-sm"
+              disabled={cacheBytes === 0}
+              onClick={handleClearCache}
+              type="button"
+            >
+              Clear
+            </button>
+          </div>
+        )}
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+npx tsc --noEmit && npm run check && npm run build
+```
+
+Expected: no errors. Then `npm run dev`, open Settings, and confirm the row shows `0 B of 2.15 GB used` with Clear disabled.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/settings-page/page.tsx
+git commit -m "feat(settings): show and clear the RAW conversion cache
+
+A 2 GB cache that a user cannot see or reclaim short of clearing site data is
+not an honest default. Hidden entirely where there is no OPFS, since zero
+would claim an empty cache rather than no cache."
+```
+
+---
+
+### Task 10: Prove a reload reuses the conversions
+
+**Files:**
+- Modify: `e2e-web/tests/perf.bench.ts`
+
+**Interfaces:**
+- Consumes: the whole feature.
+- Produces: a `secondImportMs` figure in the benchmark report.
+
+- [ ] **Step 1: Add the reload pass**
+
+In `e2e-web/tests/perf.bench.ts`, in the `MODE === "cr2"` branch, after `runMs` is measured:
+
+```ts
+    // The point of #243, measured rather than asserted: reload, re-import the
+    // same frames, and the conversion should not happen again. Same files, so
+    // the content hash matches; a new tab, so the session tier is empty and
+    // only the persistent tier can produce the saving.
+    await page.reload({ waitUntil: "load" });
+    const secondStart = Date.now();
+    await loadCr2Frames(page, FRAMES);
+    await expect(
+      page.locator(
+        '[data-testid="image-set-preview"] .generic-image-container canvas'
+      )
+    ).toHaveCount(FRAMES, { timeout: RUN_TIMEOUT });
+    secondImportMs = Date.now() - secondStart;
+```
+
+Declare `let secondImportMs: number | undefined;` beside `runMs`, and add `secondImportMs` to the `report` object.
+
+- [ ] **Step 2: Measure before the feature is on**
+
+Stash the worker wiring to get a baseline:
+
+```bash
+git stash push src/lib/raw-worker.ts
+npm run build
+MODE=cr2 FRAMES=3 npm --prefix e2e-web run bench
+git stash pop
+```
+
+Expected: `secondImportMs` within noise of `runMs` — about 6000 ms for 3 frames, because nothing is cached.
+
+- [ ] **Step 3: Measure with it on**
+
+```bash
+npm run build
+MODE=cr2 FRAMES=3 npm --prefix e2e-web run bench
+```
+
+Expected: `secondImportMs` falls to a small fraction of `runMs` — the demosaic is skipped and only the OPFS read and TIFF decode remain. `requests.wasm` should stay at 2; a rise would mean the worker is being rebuilt.
+
+- [ ] **Step 4: Record the numbers**
+
+Add a "Measured result" section to the design doc with `runMs`, `secondImportMs` and the ratio, for 3 frames and for 10.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-web/tests/perf.bench.ts docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+git commit -m "test(perf): measure that a reload reuses converted frames
+
+#243's acceptance criterion as a number rather than a claim: same frames, new
+tab, empty session tier, so any saving is the persistent tier's."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Three tiers → Tasks 4/8. Worker-only constraint → Task 8. Content-hash key → Task 6. Tool tag → Task 6. Probe and its three questions → Task 1. `BlobStore` seam → Task 4. Single-document index → Task 4. Write-before-transfer → Task 8. 2 GB LRU and the oversize guard → Task 4. Phantom and orphan → Task 5. `updateDocument` → Task 3. Asymmetric error handling → Task 8. Settings → Task 9. Four test layers → Tasks 1, 4/5/6/8, 8, 10. No gaps.
+
+**Placeholders.** None. Every code step carries the code; the only deferred decision is Task 7's backend, which is explicitly Task 1's output and has stated rules for resolving it.
+
+**Type consistency.** `BlobStore` is `read`/`write`/`remove`/`keys` throughout. `RawCache` gains `sweep` in Task 5 and the Task 8 fake implements all five members. `rawCacheKey(bytes, tag)` and `toolTag(wasmBaseUrl)` match between Tasks 6 and 8. `createRawCache({ store, budgetBytes?, now? })` matches across Tasks 4, 5, 8 and 9.
+
+**One deviation, deliberate:** Task 7 uses `createWritable` rather than the `createSyncAccessHandle` named in the issue. The sync handle is what forces this tier into a worker, and that constraint still holds and still shapes the architecture — but holding an exclusive lock across an await is a deadlock, and conversions are already serialised so the throughput difference never reaches the user. Flagged for the reviewer to overturn if Task 1 shows `createWritable` is the slow path on some host.

--- a/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
+++ b/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
@@ -1379,7 +1379,7 @@ Safari or Linux desktop users. IndexedDB round-tripped 67 MB everywhere."
 - Test: `src/lib/raw-worker.test.ts` (create)
 
 **Interfaces:**
-- Consumes: `createRawCache` (Task 4), `rawCacheKey`/`toolTag` (Task 6), `opfsBlobStore`/`opfsAvailable` (Task 7).
+- Consumes: `createRawCache` (Task 4), `rawCacheKey`/`toolTag` (Task 6), `idbBlobStore`/`blobStoreAvailable` (Task 7).
 - Produces: no new exports. Behaviour: identical bytes convert once across reloads.
 
 - [ ] **Step 1: Write the failing test**
@@ -1485,7 +1485,7 @@ In `src/lib/raw-worker.ts`, add the imports:
 ```ts
 import { createRawCache, type RawCache } from "./raw-cache";
 import { rawCacheKey, toolTag } from "./raw-cache-key";
-import { opfsAvailable, opfsBlobStore } from "./raw-cache-opfs";
+import { blobStoreAvailable, idbBlobStore } from "./raw-cache-idb";
 ```
 
 Add the cache accessor beside `runnerFor`:
@@ -1494,16 +1494,16 @@ Add the cache accessor beside `runnerFor`:
 let cache: RawCache | undefined;
 
 /**
- * The persistent tier, or nothing on a host without OPFS.
+ * The persistent tier, or nothing on a host without IndexedDB.
  *
  * Absence is not an error: the conversion path is unchanged and only slower,
  * which is exactly what every host did before this existed.
  */
 function cacheFor(): RawCache | undefined {
-  if (!opfsAvailable()) {
+  if (!blobStoreAvailable()) {
     return;
   }
-  cache ??= createRawCache({ store: opfsBlobStore() });
+  cache ??= createRawCache({ store: idbBlobStore() });
   return cache;
 }
 ```
@@ -1604,7 +1604,7 @@ conversion, so the cache can never be why a frame fails."
 - Modify: `src/app/settings-page/page.tsx`
 
 **Interfaces:**
-- Consumes: `createRawCache`, `BUDGET_BYTES` (Task 4), `opfsAvailable`/`opfsBlobStore` (Task 7).
+- Consumes: `createRawCache`, `BUDGET_BYTES` (Task 4), `blobStoreAvailable`/`idbBlobStore` (Task 7).
 - Produces: no exports.
 
 - [ ] **Step 1: Add the state and loader**
@@ -1614,7 +1614,7 @@ In `src/app/settings-page/page.tsx`, add imports:
 ```ts
 import prettyBytes from "pretty-bytes";
 import { BUDGET_BYTES, createRawCache } from "@/lib/raw-cache";
-import { opfsAvailable, opfsBlobStore } from "@/lib/raw-cache-opfs";
+import { blobStoreAvailable, idbBlobStore } from "@/lib/raw-cache-idb";
 ```
 
 Inside `SettingsPage`, beside the other `useState` calls:
@@ -1626,10 +1626,10 @@ Inside `SettingsPage`, beside the other `useState` calls:
 In the existing mount `useEffect`, after the `wasmVersions()` block:
 
 ```ts
-    // Absent on a host without OPFS, where there is no persistent tier to
+    // Absent on a host without IndexedDB, where there is no persistent tier to
     // report. Zero would claim an empty cache rather than no cache.
-    if (opfsAvailable()) {
-      createRawCache({ store: opfsBlobStore() })
+    if (blobStoreAvailable()) {
+      createRawCache({ store: idbBlobStore() })
         .usage()
         .then(setCacheBytes)
         .catch(() => setCacheBytes(null));
@@ -1643,7 +1643,7 @@ Beside `handleUpdatePath`:
 ```ts
   /** Empties the persistent RAW cache and re-reads its size. */
   const handleClearCache = async () => {
-    const cache = createRawCache({ store: opfsBlobStore() });
+    const cache = createRawCache({ store: idbBlobStore() });
     try {
       await cache.clear();
       setCacheBytes(await cache.usage());
@@ -1697,7 +1697,7 @@ git add src/app/settings-page/page.tsx
 git commit -m "feat(settings): show and clear the RAW conversion cache
 
 A 2 GB cache that a user cannot see or reclaim short of clearing site data is
-not an honest default. Hidden entirely where there is no OPFS, since zero
+not an honest default. Hidden entirely where there is no IndexedDB, since zero
 would claim an empty cache rather than no cache."
 ```
 
@@ -1754,7 +1754,7 @@ npm run build
 MODE=cr2 FRAMES=3 npm --prefix e2e-web run bench
 ```
 
-Expected: `secondImportMs` falls to a small fraction of `runMs` — the demosaic is skipped and only the OPFS read and TIFF decode remain. `requests.wasm` should stay at 2; a rise would mean the worker is being rebuilt.
+Expected: `secondImportMs` falls to a small fraction of `runMs` — the demosaic is skipped and only the IndexedDB read and TIFF decode remain. `requests.wasm` should stay at 2; a rise would mean the worker is being rebuilt.
 
 - [ ] **Step 4: Record the numbers**
 

--- a/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
+++ b/docs/superpowers/plans/2026-07-31-opfs-raw-cache.md
@@ -97,6 +97,54 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
 
     out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
     if (out.opfsAvailable) {
+      // Measured inside a dedicated worker, because `createSyncAccessHandle`
+      // exists nowhere else -- which is the whole reason the persistent tier
+      // sits in a worker. Timed against `createWritable` below so the choice
+      // between them is made on numbers rather than on reasoning.
+      const workerSource = `
+        self.onmessage = async (event) => {
+          const size = event.data;
+          try {
+            const root = await navigator.storage.getDirectory();
+            const handle = await root.getFileHandle("probe-sync.bin", { create: true });
+            if (typeof handle.createSyncAccessHandle !== "function") {
+              self.postMessage({ available: false });
+              return;
+            }
+            const access = await handle.createSyncAccessHandle();
+            const bytes = new Uint8Array(size);
+            const started = performance.now();
+            access.write(bytes, { at: 0 });
+            access.flush();
+            const written = access.getSize();
+            access.close();
+            self.postMessage({
+              available: true,
+              writeMs: Math.round(performance.now() - started),
+              written,
+            });
+            await root.removeEntry("probe-sync.bin");
+          } catch (error) {
+            self.postMessage({ available: true, error: String(error) });
+          }
+        };
+      `;
+      const worker = new Worker(
+        URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }))
+      );
+      out.opfsSync = await new Promise((resolve) => {
+        const timer = setTimeout(
+          () => resolve({ error: "timed out after 60s" }),
+          60_000
+        );
+        worker.onmessage = (event) => {
+          clearTimeout(timer);
+          resolve(event.data);
+        };
+        worker.postMessage(size);
+      });
+      worker.terminate();
+
       try {
         const root = await navigator.storage.getDirectory();
         const handle = await root.getFileHandle("probe.bin", { create: true });
@@ -150,10 +198,14 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
     `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
   );
 
-  // The only real assertion: a backend that reports success must not corrupt.
-  if (report.opfsAvailable && !report.opfsError) {
-    expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
-  }
+  // Absence fails loudly rather than passing quietly. A green test on a host
+  // with no OPFS would read as "verified" when nothing was verified at all,
+  // and this run exists precisely to find out which hosts those are. A failure
+  // here is a result to record, not a bug to fix.
+  expect(report.opfsAvailable, "OPFS is available on this host").toBe(true);
+  expect(report.opfsError, "OPFS write/read raised nothing").toBeUndefined();
+  expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
+  expect(report.idbError, "IndexedDB accepted a 67 MB value").toBeUndefined();
 });
 ```
 
@@ -179,11 +231,30 @@ For WebView2 (Windows) and WebKitGTK (Linux), push the branch and read the `e2e-
 
 - [ ] **Step 4: Record the results and decide**
 
-Add a "Probe results" section to the design doc with a row per host: `opfsAvailable`, `opfsRoundTrips`, `opfsWriteMs`, `quota`, `idbWriteMs`, and any error strings.
+Add a "Probe results" section to the design doc with a row per host:
+`opfsAvailable`, `opfsRoundTrips`, `opfsWriteMs`, `opfsSync.available`,
+`opfsSync.writeMs`, `quota`, `idbWriteMs`, and any error strings.
 
-Decision rule, stated in advance so the result is not rationalised after the fact:
-- OPFS round-trips correctly on **all four** engines (WebKit, Chromium, WKWebView, WebView2, WebKitGTK) → **approach A**.
+Decision rules, stated in advance so results are not rationalised after the fact.
+
+**Backend:**
+- OPFS round-trips correctly on **all five** engines (WebKit, Chromium, WKWebView, WebView2, WebKitGTK) → **approach A**.
 - OPFS fails or corrupts on **any** engine → **approach B**, and note which.
+
+**Write path**, if approach A wins:
+- `createSyncAccessHandle` unavailable or erroring on any engine → `createWritable`.
+- Available everywhere **and** more than 2x faster than `createWritable` on any
+  engine → `createSyncAccessHandle`, and the implementer must never hold the
+  handle across an `await`.
+- Available everywhere but within 2x → `createWritable`, because the lock
+  hazard buys nothing.
+
+**Also amend the design doc's rationale for worker placement.** It currently
+says the tier is in the worker *because* `createSyncAccessHandle` is worker-only.
+That holds only if the sync path wins. The placement is correct regardless --
+the worker already holds the source bytes, and hashing 22 MB on the main thread
+would jank the UI the RAW worker exists to keep responsive -- so state that as
+the primary reason and the API restriction as an additional one.
 
 - [ ] **Step 5: Commit**
 
@@ -1086,8 +1157,14 @@ stops a rebuilt dcraw_emu from silently serving the previous demosaic."
 **Run Task 1 first.** Implement whichever approach the probe chose. The steps below are approach **A** (OPFS); if the probe chose **B**, create `src/lib/raw-cache-idb.ts` exporting `idbBlobStore()` with the same `BlobStore` shape, backed by a new `blobs` object store in `kv.ts`, and adapt the commit message.
 
 **Files:**
-- Create: `src/lib/raw-cache-opfs.ts`
-- Test: covered by Task 1's probe and Task 10's end-to-end; not unit-tested, because jsdom has no OPFS and a mock of it would assert only that the mock works.
+- Create: `src/lib/raw-cache-opfs.ts`, `src/lib/raw-cache-opfs.test.ts`
+
+**On what the unit test is for.** It cannot prove OPFS works — that is Task 1's
+job, in a real browser. It proves *our use of the API* is right: the correct
+method names, `create: true` where a file must be made, and `close()` on the
+failure path as well as the success one. Those are the mistakes that produce a
+zero-length file that later reads as a corrupt hit rather than a miss, and they
+are invisible to a test that only exercises the happy path.
 
 **Interfaces:**
 - Consumes: `BlobStore` (Task 4).
@@ -1186,12 +1263,155 @@ export function opfsBlobStore(directoryName = DIRECTORY): BlobStore {
 }
 ```
 
-- [ ] **Step 2: Verify it type-checks and lints**
+- [ ] **Step 2: Write the usage test against a fake handle**
 
-Run: `npx tsc --noEmit && npm run check`
-Expected: no errors.
+```ts
+// src/lib/raw-cache-opfs.test.ts
+import { opfsBlobStore } from "./raw-cache-opfs";
 
-- [ ] **Step 3: Commit**
+/**
+ * A minimal stand-in for the OPFS handles this store drives.
+ *
+ * Not a claim that OPFS behaves this way -- Task 1's probe is what establishes
+ * that, in real browsers. This exists to catch the mistakes a happy-path test
+ * cannot see: a missing `create: true`, a writable left unclosed on the error
+ * path, a wrong method name.
+ */
+function fakeOpfs() {
+  const files = new Map<string, Uint8Array>();
+  const closed: string[] = [];
+  let failNextWrite = false;
+
+  const fileHandle = (name: string) => ({
+    createWritable: () =>
+      Promise.resolve({
+        close: () => {
+          closed.push(name);
+          return Promise.resolve();
+        },
+        write: (bytes: Uint8Array) => {
+          if (failNextWrite) {
+            failNextWrite = false;
+            return Promise.reject(new Error("quota exceeded"));
+          }
+          files.set(name, bytes);
+          return Promise.resolve();
+        },
+      }),
+    getFile: () =>
+      Promise.resolve({
+        arrayBuffer: () => {
+          const stored = files.get(name);
+          if (!stored) {
+            return Promise.reject(new Error("NotFoundError"));
+          }
+          return Promise.resolve(
+            stored.buffer.slice(
+              stored.byteOffset,
+              stored.byteOffset + stored.byteLength
+            )
+          );
+        },
+      }),
+  });
+
+  const directory = {
+    getFileHandle: (name: string, options?: { create?: boolean }) => {
+      if (!(files.has(name) || options?.create)) {
+        return Promise.reject(new Error("NotFoundError"));
+      }
+      if (options?.create && !files.has(name)) {
+        files.set(name, new Uint8Array());
+      }
+      return Promise.resolve(fileHandle(name));
+    },
+    keys: async function* () {
+      for (const name of Array.from(files.keys())) {
+        yield name;
+      }
+    },
+    removeEntry: (name: string) => {
+      files.delete(name);
+      return Promise.resolve();
+    },
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      storage: {
+        getDirectory: () =>
+          Promise.resolve({
+            getDirectoryHandle: () => Promise.resolve(directory),
+          }),
+      },
+    },
+  });
+
+  return {
+    closed,
+    files,
+    failWriteOnce: () => {
+      failNextWrite = true;
+    },
+  };
+}
+
+describe("the OPFS blob store", () => {
+  it("round-trips bytes through write and read", async () => {
+    fakeOpfs();
+    const store = opfsBlobStore();
+    await store.write("a", new Uint8Array([1, 2, 3]));
+    expect(Array.from((await store.read("a")) ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("returns undefined for a key that was never written", async () => {
+    fakeOpfs();
+    expect(await opfsBlobStore().read("absent")).toBeUndefined();
+  });
+
+  it("closes the writable even when the write fails", async () => {
+    const opfs = fakeOpfs();
+    const store = opfsBlobStore();
+    opfs.failWriteOnce();
+
+    await expect(store.write("b", new Uint8Array([1]))).rejects.toThrow(
+      "quota exceeded"
+    );
+
+    // The point of the test. An unclosed writable leaves a zero-length file
+    // that a later read reports as a hit, serving empty pixels.
+    expect(opfs.closed).toContain("b");
+  });
+
+  it("lists and removes keys", async () => {
+    fakeOpfs();
+    const store = opfsBlobStore();
+    await store.write("a", new Uint8Array([1]));
+    await store.write("b", new Uint8Array([2]));
+    expect((await store.keys()).toSorted()).toEqual(["a", "b"]);
+
+    await store.remove("a");
+    expect(await store.keys()).toEqual(["b"]);
+  });
+
+  it("swallows a removal of something absent", async () => {
+    fakeOpfs();
+    await expect(opfsBlobStore().remove("absent")).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test and verify it type-checks**
+
+Run: `npx jest src/lib/raw-cache-opfs.test.ts && npx tsc --noEmit && npm run check`
+Expected: PASS, five tests, no type or lint errors.
+
+Note the `write` test expects a rejection: the store lets a write error
+propagate so `raw-cache.ts` can swallow it in one place, rather than swallowing
+it twice.
+
+- [ ] **Step 4: Commit**
 
 ```bash
 git add src/lib/raw-cache-opfs.ts

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -1,0 +1,323 @@
+# Persist RAW-to-TIFF conversions so they survive a reload
+
+**Status:** designed, not implemented
+**Date:** 2026-07-31
+**Issue:** [#243](https://github.com/radiantlab/LumiLab/issues/243)
+**Depends on:** [#232](https://github.com/radiantlab/LumiLab/issues/232) Phase 4,
+the RAW conversion worker (`src/lib/raw-worker.ts`), which is complete
+
+## The problem
+
+RAW conversion is the most expensive single thing the app does, and it is pure
+recomputation: the same input bytes always produce the same TIFF. Measured on
+2026-07-31 with `e2e-web`'s benchmark against the CR2 fixture bracket:
+
+| | value |
+|---|---|
+| Import, 3 frames | 5968 ms local, 5959 ms deployed |
+| Per frame | ~2.0 s, matching the documented 1.9 s demosaic |
+| `dcraw_emu` fetches | 2, for all three frames |
+
+The cache that avoids repeating this lives in memory (`raw-preview.ts`) and
+dies with the tab. Reload the page and every frame in the bracket is converted
+again from scratch: ~19 s for a 10-frame bracket, every time.
+
+The desktop build used to keep this on disk (`src-tauri/src/image_cache/`,
+keyed by `compute_hash_for_file`) and lost it when the pipeline moved to
+WebAssembly. So this is a regression for desktop users as well as a gap for
+browser ones.
+
+Not a blocker for deployment: the app is correct without it, only slower on a
+second visit.
+
+## Approach
+
+A persistent tier behind the existing session tier, inside the RAW worker.
+
+```
+rawToTiff(path)                     [page, raw-preview.ts]
+  |- session hit?  -> return
+  `- miss -> read bytes -> tiffFor(path, bytes)
+                              `- convertRawInWorker  [raw-worker.ts]
+                                   |- hash bytes
+                                   |- persistent hit? -> read TIFF, return
+                                   `- miss -> convertRaw -> write TIFF -> return
+```
+
+Three tiers, checked in order:
+
+1. **Session**, `raw-preview.ts`, on the page. Keyed `path|size:mtime`, LRU
+   within 768 MB of RAM. Costs no file read when a frame is already resident.
+   **Unchanged by this work.**
+2. **Persistent**, inside `raw-worker.ts`. Keyed by content hash, LRU within
+   2 GB on disk.
+3. **Conversion**, the last resort.
+
+### Why the persistent tier lives in the worker
+
+`FileSystemFileHandle.createSyncAccessHandle()` is callable only from a
+dedicated Web Worker -- not the main thread, not an iframe, not a SharedWorker.
+It is excluded there deliberately, because synchronous I/O on the main thread
+blocks rendering.
+
+That constraint turns out to be a gift rather than a tax. The worker already
+receives the source bytes in order to convert them, so it can hash them without
+a second read, and the content hash never has to cross back to the page. The
+`tiffFor` seam established by the RAW worker design needs no change at all --
+which is why that seam is named for what it returns rather than what it does.
+
+## The cache key
+
+```
+key     = sha256(source bytes) + "-" + toolTag
+toolTag = first 12 hex of sha256(dcrawCommit + "\0" + dcrawArgs("in", "out").join(" "))
+```
+
+`dcrawCommit` is `tools.dcraw_emu.commit` from `versions.json`. The args are
+serialised by calling `dcrawArgs` with fixed placeholder paths, so the tag
+tracks the *flags* and changes when they do, without varying per frame.
+
+### Why content hash, not path
+
+This is a correctness requirement in the browser, not an optimisation.
+`registerSessionFile` (`src/lib/vfs.ts:44`) mints `/session/${nextId()}/${name}`
+from a counter that restarts each session. So `/session/1/capt01.CR2` in one
+session and `/session/1/other.CR2` in the next are **the same string for
+different bytes**. A path-keyed persistent cache would serve the wrong image.
+
+Content addressing also makes the multi-tab case benign: identical bytes
+produce an identical key and an identical TIFF, so two tabs converting the same
+bracket duplicate a write and never corrupt anything.
+
+### Why the tool tag
+
+Not in #243, and load-bearing. Keying on content alone means that if
+`dcrawArgs` changes, or `dcraw_emu.wasm` is rebuilt from newer sources -- which
+is exactly what [#244](https://github.com/radiantlab/LumiLab/issues/244)
+proposes to automate -- every cached TIFF becomes silently stale. The app would
+serve pixels produced by a *different demosaic* while reporting success.
+
+`raw-preview.ts` goes to real lengths to keep the preview and the pipeline
+byte-identical (verified: sha256 `8137c98a...` across the browser preview path,
+the pipeline, and a native build). Quietly serving last-build's pixels would
+undo that guarantee.
+
+Folding the tag into the key rather than validating it on read means a tool
+change simply misses, stale entries age out by LRU, and a rollback re-hits its
+old entries instead of having discarded them.
+
+`wasmVersions()` (`src/lib/build-versions.ts`) already exposes
+`tools.dcraw_emu.commit`. **One trap:** that module hardcodes
+`WASM_BASE_URL = "/wasm"` as a relative fetch, and in a worker a relative URL
+resolves against the worker's own chunk, not the document. The worker must
+resolve `versions.json` from the absolute `request.wasmBaseUrl` it is already
+given -- the same hazard `raw-preview.ts` documents for the wasm base URL.
+
+### Cost
+
+`crypto.subtle.digest` over a 22 MB frame is roughly 25-50 ms, paid only on a
+session-cache miss, where the bytes have been read anyway. About 0.5 s across a
+10-frame bracket, against the ~19 s of conversion it avoids.
+
+## Storage backend: decided by probe
+
+Two candidates. The probe runs first and picks one; we do not build both.
+
+### A. OPFS blobs + IndexedDB index (recommended)
+
+TIFFs in OPFS, named by key, written and read through `createSyncAccessHandle`
+inside the worker. Index in the existing `documents` store.
+
+- **For:** fastest read path, no structured clone of 67 MB, and OPFS generally
+  gets a far larger quota than IndexedDB -- which matters at 2 GB, since WebKit
+  has historically been stingy with IndexedDB per origin.
+- **Against:** two storage systems that can desynchronise. See Reconciliation.
+
+### B. IndexedDB only, extending `kv.ts` (fallback)
+
+A third object store beside `documents` and `files`, blobs as `ArrayBuffer`.
+
+- **For:** one storage system, already proven in all three Tauri webviews --
+  presets, settings and run history depend on it in production today, so the
+  compatibility risk is zero. Index and blob update in a **single transaction**,
+  eliminating the whole orphan/phantom class of bugs in A.
+- **Against:** a 67 MB structured clone on every read and write, and large-value
+  IndexedDB performance is meaningfully worse than an OPFS sync handle.
+
+### C. OPFS with IndexedDB fallback: rejected
+
+Two caching implementations to keep honest. #243 itself warns that "a second
+caching implementation behind `isTauri()` would be the thing that drifts".
+Reconsider only if the probe shows OPFS working on some hosts but not others.
+
+### What the probe must answer
+
+1. Does OPFS open, write, read back and delete a ~67 MB blob in WKWebView
+   (macOS), WebView2 (Windows) and WebKitGTK (Linux)?
+2. What does `navigator.storage.estimate()` actually grant on each host, for
+   both backends?
+3. Does IndexedDB accept ~2 GB of large values on those same hosts?
+
+OPFS is used nowhere in the codebase today, and its behaviour in the Tauri
+webviews has never been tested -- `PRD.md:132` records that plainly. WebKitGTK
+is the doubtful one, and Safari has a history of OPFS write bugs.
+
+## Components
+
+### New
+
+| File | Purpose |
+|---|---|
+| `src/lib/raw-cache.ts` | The tier: lookup, store, index, eviction. Storage injected. |
+| `src/lib/raw-cache-opfs.ts` | `opfsBlobStore()`. The only file touching OPFS, so Jest never imports it and the probe can exercise it alone. **Under B this is `raw-cache-idb.ts` instead; exactly one of the two exists.** |
+| `src/lib/raw-cache.types.ts` | `BlobStore` and index records, importable without the implementation. |
+
+### Modified
+
+- `src/lib/raw-worker.ts` -- hash, consult the cache, store on miss.
+- `src/lib/storage/kv.ts` -- add `updateDocument(key, fn)`, a get+put inside one
+  transaction. See Concurrency.
+- The Settings page -- usage read-out and Clear button.
+
+### The storage seam
+
+```ts
+export interface BlobStore {
+  read(key: string): Promise<Uint8Array | undefined>;
+  write(key: string, bytes: Uint8Array): Promise<void>;
+  remove(key: string): Promise<void>;
+  /** Every key present. For reconciliation against the index. */
+  keys(): Promise<string[]>;
+}
+```
+
+Follows the injection style already used for `RawSourceIo`, `ModuleLoader` and
+`tiffFor`, so the tier is testable in jsdom, which has no OPFS. OPFS satisfies
+it; IndexedDB satisfies it if the probe sends us to B; a `Map`-backed fake
+satisfies it in tests. That is what keeps the A/B decision from rippling past
+one file.
+
+### The index
+
+One JSON document in the existing `documents` store under `raw-cache-index`,
+mapping `key -> { size, lastUsed }`.
+
+At 2 GB / 67 MB that is about 30 entries, so a single document is the right
+grain: each index update is atomic, and the page can read it directly, which is
+what lets Settings report usage without involving the worker.
+
+## Data flow, inside the worker
+
+```
+1. key  = sha256(bytes) + "-" + toolTag        toolTag from versions.json @ wasmBaseUrl
+2. hit  = await cache.get(key)   -> touch lastUsed, return
+3. miss -> tiff = await convertRaw(runner, path, bytes)
+4. await cache.put(key, tiff)    -> write blob, update index, evict to 2 GB
+5. postMessage(tiff, [tiff.buffer])            <- transfer LAST
+```
+
+**Step 4 must precede step 5, and that is a correctness constraint rather than
+a preference.** `postMessage` with a transfer detaches the buffer, so caching
+afterwards would persist a zero-byte file while reporting success -- the same
+detached-`ArrayBuffer` failure fixed in `93ba5fc`. Writing first costs ~100 ms
+on a 67 MB TIFF and removes the hazard entirely.
+
+## Eviction
+
+Budget **2 GB**, fixed. LRU by `lastUsed`, evicting until total is at or under
+budget, never the entry just added. Mirrors `evictDownToBudget` in
+`raw-preview.ts` so both tiers read alike.
+
+One guard the session tier does not need: a blob larger than the whole budget
+is not cached at all, rather than evicting everything and then itself.
+
+## Reconciliation
+
+The price of approach A, and unnecessary under B. Two failure shapes:
+
+- **Phantom** -- index entry present, blob gone, e.g. the browser reclaimed
+  storage. `get` reads the index, then the blob; a missing blob drops the index
+  entry and reports a miss. Self-healing, no sweep required.
+- **Orphan** -- blob written, index write lost to a crash. Invisible to
+  eviction, so it consumes disk forever. Swept once per session on first use:
+  `keys()`, delete anything absent from the index. About 30 keys, so it is
+  cheap.
+
+Writes go blob-first then index, so an interrupted write leaves the recoverable
+orphan rather than the phantom.
+
+## Concurrency
+
+Mostly handled by construction. The worker serialises conversions through the
+queue in `raw-worker-client.ts`, so there is no concurrent `put` from that side.
+Two real cases remain:
+
+- **Settings "Clear" racing a write.** The index is a read-modify-write, and
+  `kv.ts`'s `run()` does one request per transaction, so this needs
+  `updateDocument(key, fn)` doing get+put inside a single transaction. This is
+  the only change to existing storage code.
+- **Two tabs converting the same bracket.** Benign, because the store is
+  content-addressed: identical bytes give an identical key and an identical
+  TIFF, so the worst case is a duplicate write.
+
+## Error handling
+
+Asymmetric, deliberately:
+
+- A cache **read** failure is treated as a miss, and the frame is converted.
+- A cache **write** failure is logged and swallowed. The conversion already
+  succeeded and the user should get their image whether or not the disk
+  cooperated.
+
+**The cache may never be the reason a conversion fails.**
+
+## Settings
+
+One row beside the tool versions the page already carries:
+
+```
+RAW conversion cache        1.2 GB of 2 GB used     [Clear]
+```
+
+Usage reads the index document directly from the page. Clearing from the page
+is fine: only `createSyncAccessHandle()` is worker-restricted;
+`getDirectory()` and `removeEntry()` work on the main thread.
+
+## Testing
+
+**1. The probe, first, because it gates A vs B.** Runs in the desktop suite
+(WebdriverIO -- macOS, Ubuntu, Windows in CI) and the browser suite (Playwright
+-- WebKit, Chromium). Opens OPFS, writes ~67 MB, reads back and verifies the
+bytes, deletes, reports `navigator.storage.estimate()`; then the same volume
+through IndexedDB. Output is a per-host table answering the three questions
+above.
+
+**2. Unit** (Jest, fake `BlobStore`): hit, miss, eviction order, budget guard,
+phantom self-heal, orphan sweep, write-failure swallowed, and a changed tool tag
+causing a miss.
+
+**3. Integration**: convert once, request identical bytes again, assert the
+injected converter ran exactly once -- the counting-injection pattern
+`raw-convert.test.ts` already uses.
+
+**4. End to end, with a number rather than a claim.** `e2e-web`'s benchmark
+already measures this path: `MODE=cr2` reports 5968 ms for 3 frames with 2 wasm
+fetches. Adding a reload-and-reimport pass gives the acceptance criterion
+directly -- the second import should fall by roughly the conversion time while
+wasm fetches stay at 2.
+
+## What does not change
+
+- `raw-preview.ts`. The session tier, its budget and its key are untouched.
+- The `tiffFor` seam and the worker message protocol.
+- `dcrawArgs`. There is still exactly one flag set, so the preview cannot drift
+  from what the pipeline measures.
+- Pipeline behaviour on a cache miss, which is what it does today.
+
+## Out of scope
+
+- Memoising fingerprint -> content hash so an unchanged file skips the read
+  *and* the digest on a later session. Worth considering later, not worth
+  building first.
+- Persisting anything other than RAW-to-TIFF conversions.
+- A user-facing toggle to disable persistence. Speculative until asked for.

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -438,8 +438,68 @@ injected converter ran exactly once -- the counting-injection pattern
 **4. End to end, with a number rather than a claim.** `e2e-web`'s benchmark
 already measures this path: `MODE=cr2` reports 5968 ms for 3 frames with 2 wasm
 fetches. Adding a reload-and-reimport pass gives the acceptance criterion
-directly -- the second import should fall by roughly the conversion time while
-wasm fetches stay at 2.
+directly -- the second import should fall by roughly the conversion time. See
+"Measured result" below for what "wasm fetches stay at 2" turns into once the
+benchmark actually reloads the page.
+
+## Measured result
+
+Measured 2026-07-31 with the reload pass added to `e2e-web/tests/perf.bench.ts`
+in Task 10, against the local static build (`npm run build`, then `MODE=cr2
+FRAMES=<n> npm --prefix e2e-web run bench`, `dangerouslyDisableSandbox` needed
+for both in this agent's sandbox -- see the module docstring's note on
+inflated numbers, which applies to `npm run build`'s Turbopack dev server too).
+
+| | 3 frames | 10 frames |
+|---|---|---|
+| `runMs` (first import, cache miss + write) | 10094 / 8456 / 9074 (avg 9208) | 25715 |
+| `secondImportMs` (reload, reimport, cache hit) | 2012 / 1949 / 1970 (avg 1977) | 5198 |
+| ratio (second / first) | 21.5% | 20.2% |
+| `requests.wasm` | 4 | 4 |
+
+Three repeated 3-frame runs are reported individually because a single sample
+was not enough to trust against the 5968 ms baseline below; ten frames was run
+once, at ~26 s for the pair, well within reasonable time.
+
+**`secondImportMs` falls to about a fifth of `runMs`, at both frame counts.**
+The demosaic (~1.9 s/frame) is skipped entirely; what remains is the
+IndexedDB read of ~67 MB/frame plus the TIFF decode. This is the acceptance
+criterion in #243, measured rather than asserted.
+
+**`requests.wasm` is 4, not 2 -- expected, once broken down, not a
+regression.** The pre-reload baseline counted `/wasm/` requests across *one*
+page load; this benchmark now spans two (initial load, then `page.reload()`).
+`wasmRequestDetail` for a representative 3-frame run:
+
+```
+versions.json   (1 KB)   -- first import: computing the cache key's tool tag
+dcraw_emu.js   (20 KB)   -- first import: cache miss, converting
+dcraw_emu.wasm (312 KB)  -- first import: cache miss, converting
+versions.json   (0 KB)   -- second import: computing the cache key's tool tag
+```
+
+`dcraw_emu.js`/`.wasm` appear exactly **once**, on the first import only, at
+both 3 and 10 frames. On the second import, `convertWithCache`'s `key()` call
+fetches `versions.json` to build the tag, finds a persistent-cache hit, and
+returns without ever calling `convertRaw` -- so `runnerFor`'s compiled
+`dcraw_emu` module is not just reused, it is never touched a second time. This
+is stronger evidence than a flat fetch count: the benchmark's own listener
+(`page.on("requestfinished")`) fires for HTTP-cache-served requests too --
+the second `versions.json` above shows `kb: 0`, a cache hit that still
+produced an event -- so the *absence* of a second `dcraw_emu.wasm` entry is
+not the listener missing a cached fetch, it is `convertRaw` never running.
+
+**A control run confirms the comparison is real.** Temporarily reverting
+`raw-worker.ts` to its pre-cache form (`git show 390bbf2^:src/lib/raw-worker.ts`)
+and rebuilding gives, for 3 frames: `runMs` 8036 ms, `secondImportMs` 7944 ms
+-- equal within noise, because nothing is cached, and `dcraw_emu.js`/`.wasm`
+each fetched twice (once per import, the second served from the HTTP cache at
+`kb: 0`). This is also the closest available reproduction of the pre-cache
+baseline: this sandbox's `runMs` runs 8000-9200 ms for 3 frames on both the
+cached and uncached worker, well above the 5968 ms recorded elsewhere, so the
+gap from 5968 is environment speed, not the persistent tier's write cost --
+the write happens on every first-import frame here too and the number is the
+same with and without it.
 
 ## What does not change
 

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -457,9 +457,14 @@ inflated numbers, which applies to `npm run build`'s Turbopack dev server too).
 | ratio (second / first) | 21.5% | 20.2% |
 | `requests.wasm` | 4 | 4 |
 
-Three repeated 3-frame runs are reported individually because a single sample
-was not enough to trust against the 5968 ms baseline below; ten frames was run
-once, at ~26 s for the pair, well within reasonable time.
+Three 3-frame runs are reported individually because a single sample was not
+enough to trust against the 5968 ms baseline below; ten frames was run once,
+at ~26 s for the pair, well within reasonable time. A fourth 3-frame run's raw
+JSON was lost to output truncation before it was saved -- its `requests.wasm`
+shape was confirmed identical (one `dcraw_emu.js`, one `dcraw_emu.wasm`, two
+`versions.json`) but its `runMs`/`secondImportMs` pair was not recovered, so
+it is excluded rather than guessed at. The averages above are three runs, not
+four.
 
 **`secondImportMs` falls to about a fifth of `runMs`, at both frame counts.**
 The demosaic (~1.9 s/frame) is skipped entirely; what remains is the
@@ -489,17 +494,30 @@ the second `versions.json` above shows `kb: 0`, a cache hit that still
 produced an event -- so the *absence* of a second `dcraw_emu.wasm` entry is
 not the listener missing a cached fetch, it is `convertRaw` never running.
 
-**A control run confirms the comparison is real.** Temporarily reverting
-`raw-worker.ts` to its pre-cache form (`git show 390bbf2^:src/lib/raw-worker.ts`)
-and rebuilding gives, for 3 frames: `runMs` 8036 ms, `secondImportMs` 7944 ms
--- equal within noise, because nothing is cached, and `dcraw_emu.js`/`.wasm`
-each fetched twice (once per import, the second served from the HTTP cache at
-`kb: 0`). This is also the closest available reproduction of the pre-cache
-baseline: this sandbox's `runMs` runs 8000-9200 ms for 3 frames on both the
-cached and uncached worker, well above the 5968 ms recorded elsewhere, so the
-gap from 5968 is environment speed, not the persistent tier's write cost --
-the write happens on every first-import frame here too and the number is the
-same with and without it.
+**A control run confirms the reload comparison is real.** Temporarily
+reverting `raw-worker.ts` to its pre-cache form
+(`git show 390bbf2^:src/lib/raw-worker.ts`) and rebuilding gives, for 3
+frames: `runMs` 8036 ms, `secondImportMs` 7944 ms -- equal within noise,
+because nothing is cached, and `dcraw_emu.js`/`.wasm` each fetched twice
+(once per import, the second served from the HTTP cache at `kb: 0`). That is
+the acceptance-criterion comparison this task exists to make, and it holds.
+
+**What the control does *not* settle: why `runMs` itself (8456-10094 ms,
+3-frame) runs above the 5968 ms baseline measured earlier today.** The
+control's 8036 ms is a **single sample**, and it happens to be the fastest of
+all four cache-on/cache-off runs recorded in this session -- one data point
+below a three-run cache-on spread does not distinguish "this environment
+generally runs slower than whatever host measured 5968 ms" from "the
+persistent write adds a modest cost to the first import that the control
+happened to under-sample." Both are consistent with what was measured; only
+the first is consistent with the *design*, since the write is documented at
+~100 ms/frame (see "Cost" above `crypto.subtle.digest`'s estimate, and the
+"Step 4 must precede step 5" note), which would be too small to explain a
+~1200-2100 ms gap on its own -- but "too small on paper" is not the same as
+measured. Settling it would need several more cache-off control runs at the
+same n as the cache-on runs, ideally on the same host that produced 5968 ms,
+which this pass did not attempt because it would not change the reload
+result above. Left here as an open question rather than resolved.
 
 ## What does not change
 

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -55,16 +55,24 @@ Three tiers, checked in order:
 
 ### Why the persistent tier lives in the worker
 
-`FileSystemFileHandle.createSyncAccessHandle()` is callable only from a
-dedicated Web Worker -- not the main thread, not an iframe, not a SharedWorker.
-It is excluded there deliberately, because synchronous I/O on the main thread
-blocks rendering.
+Primarily because the worker already holds the bytes. It receives them in
+order to convert them, so hashing there costs no second read, and the content
+hash never has to cross back to the page. Doing that hash on the main thread
+instead would mean shipping a 22 MB frame across `postMessage` just to jank
+the UI the RAW worker exists to keep responsive -- the same class of stall
+`e2e-web/tests/pipeline.spec.ts` guards against for conversion itself.
 
-That constraint turns out to be a gift rather than a tax. The worker already
-receives the source bytes in order to convert them, so it can hash them without
-a second read, and the content hash never has to cross back to the page. The
-`tiffFor` seam established by the RAW worker design needs no change at all --
-which is why that seam is named for what it returns rather than what it does.
+`FileSystemFileHandle.createSyncAccessHandle()` being callable only from a
+dedicated Web Worker -- not the main thread, not an iframe, not a
+SharedWorker -- is an additional reason, not the deciding one. That
+restriction is why synchronous I/O on the main thread is excluded at all, but
+it only bears on this placement if the probe below sends the write path to
+`createSyncAccessHandle`; if `createWritable` wins instead, the placement
+holds anyway, on the first reason alone.
+
+The `tiffFor` seam established by the RAW worker design needs no change at all
+-- which is why that seam is named for what it returns rather than what it
+does.
 
 ## The cache key
 
@@ -161,6 +169,62 @@ Reconsider only if the probe shows OPFS working on some hosts but not others.
 OPFS is used nowhere in the codebase today, and its behaviour in the Tauri
 webviews has never been tested -- `PRD.md:132` records that plainly. WebKitGTK
 is the doubtful one, and Safari has a history of OPFS write bugs.
+
+## Probe results
+
+Measured 2026-07-31 with `e2e-web/tests/storage-probe.spec.ts` against the
+static export (`npm run build`, then `npx playwright test
+tests/storage-probe.spec.ts --project=<name>` from `e2e-web`). Two of the five
+engines the decision rules need; the other three are below.
+
+| Host | opfsAvailable | opfsRoundTrips | opfsWriteMs | opfsSync.available | opfsSync.writeMs | quota | idbWriteMs | errors |
+|---|---|---|---|---|---|---|---|---|
+| WebKit (Playwright, macOS) | true | false | -- | true | -- | 1000 MB | 186 | `UnknownError: The operation failed for an unknown transient reason (e.g. out of memory).` -- identical on both write paths |
+| Chromium (Playwright, macOS) | true | true | 78 | true | 115 | 4096 MB | 41 | none |
+| WKWebView (macOS, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+
+**Chromium round-trips cleanly.** Both write paths succeed, and the 67 MB
+readback matches the source byte-for-byte.
+
+**WebKit's OPFS write fails, on both paths, with the same error.** Not a
+missing API -- `opfsAvailable` and `opfsSync.available` both report `true` --
+and not naive quota exhaustion at 67 MB under a reported 1000 MB quota. The
+main-thread `createWritable` call and the worker's `createSyncAccessHandle`
+call raise the identical `UnknownError` independently, which points at
+something WebKit's OPFS implementation does at this blob size rather than at
+either API path specifically. This is Playwright's bundled WebKit on macOS in
+an ephemeral profile, not WKWebView -- the row the "OPFS fails on any engine
+-> B" rule actually needs. If it reproduces on WKWebView, that rule fires and
+the backend is B. If WKWebView round-trips cleanly, the WebKit-only failure
+does not by itself decide anything, since the rule is stated per engine and
+WebKit is not one of the five it names.
+
+**The write-path timing is not comparable as instrumented.** `opfsSync.writeMs`
+brackets only `access.write` + `flush` inside the worker, on a freshly
+allocated all-zero buffer; `opfsWriteMs` brackets `write` + `close` on the main
+thread, on the patterned source buffer. Different spans, different payloads.
+Chromium's 115 ms vs. 78 ms cannot be read as "`createWritable` is faster" or
+fed into the 2x rule under "Write path" above -- a rerun timing the same span
+over the same bytes would be needed before that comparison means anything.
+
+**`idbRoundTrips` is not in the table above deliberately.** The probe never
+reads the value back from IndexedDB; it treats the write transaction's
+`oncomplete` as success. Both engines report a completed write and no
+`idbError`, which is weaker than OPFS's actual byte comparison and shouldn't
+be read as equivalent verification.
+
+**Still needed:** all three Tauri webviews. `e2e-tests/test/specs/storage-probe.e2e.ts`
+exists, ports the same probe body to `browser.execute`, and type-checks
+(`npx tsc --noEmit` from `e2e-tests`), but has not run anywhere -- it needs the
+debug Tauri binary that `wdio.conf.js`'s `onPrepare` builds
+(`npm run tauri build -- --debug --no-bundle --features e2e-driver`), which
+this pass did not produce. WKWebView can run locally afterward with
+`npm run test:e2e:desktop` on macOS; WebView2 and WebKitGTK need the
+`e2e-tests` CI job on its Windows and Ubuntu runners. Until those three rows
+are filled in, neither the backend (A vs. B) nor the write path can be decided
+-- this section is what the decision needs, not the decision itself.
 
 ## Components
 

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -289,6 +289,28 @@ reads the value back from IndexedDB; it treats the write transaction's
 `idbError` on every run, which is weaker than OPFS's actual byte comparison
 and shouldn't be read as equivalent verification.
 
+**The probe's CI assertions now guard IndexedDB, not OPFS.** On CI's WebKit
+runner and on WebKitGTK 605.1.15, `getDirectory` comes back absent -- not
+slow, not quota-limited, absent (`opfsAvailable: false`, `quota: null`; see
+`eb0aec8`). That is a different reading from the WebKit row already in the
+table above, where the macOS Playwright host has the API present
+(`opfsAvailable: true`) but the *control write* fails under host memory
+pressure -- the confound this section spends most of its length on. Two
+engines with no OPFS at all in CI is what decided the backend: the
+persistent cache was built on approach B (`raw-cache-idb.ts`), and the OPFS
+branch above is what the app does not ship with. Both spec files
+(`e2e-web/tests/storage-probe.spec.ts` and
+`e2e-tests/test/specs/storage-probe.e2e.ts`) still measure and print every
+OPFS field in the table above, but only `idbError`/`idbRoundTrips` -- the
+weaker check described in the paragraph above, and still the app's real
+dependency -- fail the build. The control-write and round-trip assertions
+stay, gated behind `opfsAvailable`, so an engine that does claim OPFS and
+then corrupts data still fails, and a host where `opfsAvailable` is `true`
+but the control write fails (the macOS row above) still reports itself
+inconclusive rather than green; only OPFS's absence stopped being fatal,
+which is what let CI's WebKit and WebKitGTK runs go green without
+reopening the question this section answered.
+
 **Still needed:** an unloaded rerun of the WebKit case (the current numbers
 are confounded, not negative), plus all three Tauri webviews.
 `e2e-tests/test/specs/storage-probe.e2e.ts` exists, ports the same probe body

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -177,54 +177,98 @@ static export (`npm run build`, then `npx playwright test
 tests/storage-probe.spec.ts --project=<name>` from `e2e-web`). Two of the five
 engines the decision rules need; the other three are below.
 
-| Host | opfsAvailable | opfsRoundTrips | opfsWriteMs | opfsSync.available | opfsSync.writeMs | quota | idbWriteMs | errors |
-|---|---|---|---|---|---|---|---|---|
-| WebKit (Playwright, macOS) | true | false | -- | true | -- | 1000 MB | 186 | `UnknownError: The operation failed for an unknown transient reason (e.g. out of memory).` -- identical on both write paths |
-| Chromium (Playwright, macOS) | true | true | 78 | true | 115 | 4096 MB | 41 | none |
-| WKWebView (macOS, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
-| WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
-| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+The spec now runs each OPFS write path twice: once as a single call across the
+whole 67 MB blob, once as 8 MB slices through the same handle
+(`opfsChunkedWriteMs`, `opfsSyncChunked`). Chunking is the standard mitigation
+for a large OPFS write, and a chunked pass that survives where the
+single-shot one failed would point at the call shape rather than at OPFS
+itself -- see the spec's module docstring.
 
-**Chromium round-trips cleanly.** Both write paths succeed, and the 67 MB
-readback matches the source byte-for-byte.
+| Host | opfsAvailable | opfsRoundTrips | opfsWriteMs | opfsChunkedRoundTrips | opfsChunkedWriteMs | opfsSync.writeMs | opfsSyncChunked.writeMs | quota | idbWriteMs | errors |
+|---|---|---|---|---|---|---|---|---|---|---|
+| WebKit (Playwright, macOS) | true | false | -- | inconclusive | -- | -- | -- | 1000 MB | 169-296 | see below -- host-level, not a finding about OPFS |
+| Chromium (Playwright, macOS) | true | true | 78-103 | true | 97 | 115-179 | 120 | 3072-4096 MB | 41-66 | none |
+| WKWebView (macOS, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
 
-**WebKit's OPFS write fails, on both paths, with the same error.** Not a
-missing API -- `opfsAvailable` and `opfsSync.available` both report `true` --
-and not naive quota exhaustion at 67 MB under a reported 1000 MB quota. The
-main-thread `createWritable` call and the worker's `createSyncAccessHandle`
-call raise the identical `UnknownError` independently, which points at
-something WebKit's OPFS implementation does at this blob size rather than at
-either API path specifically. This is Playwright's bundled WebKit on macOS in
-an ephemeral profile, not WKWebView -- the row the "OPFS fails on any engine
--> B" rule actually needs. If it reproduces on WKWebView, that rule fires and
-the backend is B. If WKWebView round-trips cleanly, the WebKit-only failure
-does not by itself decide anything, since the rule is stated per engine and
-WebKit is not one of the five it names.
+Chromium and WebKit each show a range because the spec was run more than
+once while diagnosing the WebKit result below; the numbers move host-load to
+host-load but the pass/fail outcome was stable across every Chromium run and
+every WebKit run.
 
-**The write-path timing is not comparable as instrumented.** `opfsSync.writeMs`
-brackets only `access.write` + `flush` inside the worker, on a freshly
-allocated all-zero buffer; `opfsWriteMs` brackets `write` + `close` on the main
-thread, on the patterned source buffer. Different spans, different payloads.
-Chromium's 115 ms vs. 78 ms cannot be read as "`createWritable` is faster" or
-fed into the 2x rule under "Write path" above -- a rerun timing the same span
-over the same bytes would be needed before that comparison means anything.
+**Chromium round-trips cleanly on all four paths, single-shot and chunked,
+main thread and worker.** All four writes -- `createWritable` single-shot,
+`createWritable` chunked, `createSyncAccessHandle` single-shot,
+`createSyncAccessHandle` chunked -- complete and read back byte-identical.
+This is the one clean chunked-vs-single-shot comparison available so far: the
+chunked writer's code path is correct, and on an engine that already handles
+the single-shot write, chunking neither breaks anything nor buys much
+(97 ms vs. 78-103 ms for `createWritable`; 120 ms vs. 115-179 ms for
+`createSyncAccessHandle` -- see the timing-comparability caveat below before
+reading either pair as a real speed difference).
+
+**The WebKit row above needs correction from what an earlier version of this
+document said, and the correction is the more important result of this
+pass.** The original single-shot run (recorded when this section was first
+written) failed with `UnknownError: The operation failed for an unknown
+transient reason (e.g. out of memory).` on a 67 MB write, and that entry read
+this as "not naive quota exhaustion at 67 MB," reasoning from the blob size
+against a reported 1000 MB quota. Chasing whether chunking fixed that led to
+a machine-level check that overturns the "at 67 MB" framing entirely: a
+follow-up run of a **4-byte** OPFS write, on the same host, in the same
+session, failed with the *identical* `UnknownError`, at the *same* stage
+(`navigator.storage.getDirectory()`, before any write is attempted at all).
+`memory_pressure` on the host at the time showed roughly 60-230 MB of a 16 GB
+machine free across repeated checks, with 9.3M page-outs already recorded --
+this is a real desktop under its owner's normal multi-app load, not a CI
+runner reserved for the test. A host that cannot open the OPFS root directory
+for 4 bytes cannot tell you anything about whether it can write 67 MB in one
+call versus eight -- both the original single-shot number and the new chunked
+one are **confounded by host memory pressure, not evidence about WebKit's
+OPFS implementation**. Both are marked accordingly in the table rather than
+left to read as findings.
+
+This is Playwright's bundled WebKit on macOS in an ephemeral profile, not
+WKWebView -- the row the "OPFS fails on any engine -> B" rule actually needs,
+and it needs a result from an unloaded host (CI, or this same machine at
+rest) before it counts as one. If WKWebView fails the same way on a host that
+also fails a 4-byte control write, that is the same confound repeated, not
+independent confirmation. If WKWebView fails while a same-session 4-byte
+control succeeds, that is a real, engine-level finding and the "any engine"
+rule fires. If WKWebView round-trips cleanly, the WebKit-only result does not
+decide anything on its own, since the rule is stated per engine and WebKit is
+not one of the five it names.
+
+**The write-path timing is not comparable as instrumented, independent of the
+confound above.** `opfsSync.writeMs` brackets only `access.write` + `flush`
+inside the worker, on a freshly allocated all-zero buffer; `opfsWriteMs`
+brackets `write` + `close` on the main thread, on the patterned source buffer.
+Different spans, different payloads. The same gap exists between
+`opfsSyncChunked.writeMs` and `opfsChunkedWriteMs`. None of Chromium's four
+numbers should be fed into the 2x rule under "Write path" above -- a rerun
+timing the same span over the same bytes would be needed before any pair of
+them means anything.
 
 **`idbRoundTrips` is not in the table above deliberately.** The probe never
 reads the value back from IndexedDB; it treats the write transaction's
 `oncomplete` as success. Both engines report a completed write and no
-`idbError`, which is weaker than OPFS's actual byte comparison and shouldn't
-be read as equivalent verification.
+`idbError` on every run, which is weaker than OPFS's actual byte comparison
+and shouldn't be read as equivalent verification.
 
-**Still needed:** all three Tauri webviews. `e2e-tests/test/specs/storage-probe.e2e.ts`
-exists, ports the same probe body to `browser.execute`, and type-checks
-(`npx tsc --noEmit` from `e2e-tests`), but has not run anywhere -- it needs the
-debug Tauri binary that `wdio.conf.js`'s `onPrepare` builds
+**Still needed:** an unloaded rerun of the WebKit case (the current numbers
+are confounded, not negative), plus all three Tauri webviews.
+`e2e-tests/test/specs/storage-probe.e2e.ts` exists, ports the same probe body
+(including the chunked paths) to `browser.execute`, and type-checks
+(`npx tsc --noEmit` from `e2e-tests`), but has not run anywhere -- it needs
+the debug Tauri binary that `wdio.conf.js`'s `onPrepare` builds
 (`npm run tauri build -- --debug --no-bundle --features e2e-driver`), which
 this pass did not produce. WKWebView can run locally afterward with
 `npm run test:e2e:desktop` on macOS; WebView2 and WebKitGTK need the
-`e2e-tests` CI job on its Windows and Ubuntu runners. Until those three rows
-are filled in, neither the backend (A vs. B) nor the write path can be decided
--- this section is what the decision needs, not the decision itself.
+`e2e-tests` CI job on its Windows and Ubuntu runners. Until those rows are
+filled in from a host that also passes the 4-byte control, neither the
+backend (A vs. B) nor the write path can be decided -- this section is what
+the decision needs, not the decision itself.
 
 ## Components
 

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -78,7 +78,7 @@ does.
 
 ```
 key     = sha256(source bytes) + "-" + toolTag
-toolTag = first 12 hex of sha256(dcrawCommit + "\0" + dcrawArgs("in", "out").join(" "))
+toolTag = first 12 hex of sha256(dcrawCommit + ":" + dcrawArgs("in", "out").join(" "))
 ```
 
 `dcrawCommit` is `tools.dcraw_emu.commit` from `versions.json`. The args are

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -78,12 +78,18 @@ does.
 
 ```
 key     = sha256(source bytes) + "-" + toolTag
-toolTag = first 12 hex of sha256(dcrawCommit + ":" + dcrawArgs("in", "out").join(" "))
+toolTag = first 12 hex of sha256(dcrawCommit + ":" + emscripten + ":" + dcrawArgs("in", "out").join(" "))
 ```
 
-`dcrawCommit` is `tools.dcraw_emu.commit` from `versions.json`. The args are
-serialised by calling `dcrawArgs` with fixed placeholder paths, so the tag
-tracks the *flags* and changes when they do, without varying per frame.
+`dcrawCommit` is `tools.dcraw_emu.commit` from `versions.json`, and
+`emscripten` is that document's top-level `emscripten` field -- the toolchain
+version, not a LibRaw property. Both are folded in, not just the commit:
+review found that keying on the commit alone let a rebuild from the same
+LibRaw source on a bumped Emscripten (what #244 automates) produce an
+identical key over potentially different bytes, serving a stale TIFF as a
+valid hit. The args are serialised by calling `dcrawArgs` with fixed
+placeholder paths, so the tag tracks the *flags* and changes when they do,
+without varying per frame.
 
 ### Why content hash, not path
 
@@ -306,13 +312,24 @@ the decision needs, not the decision itself.
 | `src/lib/raw-cache.ts` | The tier: lookup, store, index, eviction. Storage injected. |
 | `src/lib/raw-cache-opfs.ts` | `opfsBlobStore()`. The only file touching OPFS, so Jest never imports it and the probe can exercise it alone. **Under B this is `raw-cache-idb.ts` instead; exactly one of the two exists.** |
 | `src/lib/raw-cache.types.ts` | `BlobStore` and index records, importable without the implementation. |
+| `src/lib/raw-cache-quota.ts` | `estimateQuotaBytes()` and `persistStorageBestEffort()`. Added in the F2 review fix: the one file that touches `navigator.storage`, for the same Jest-testability reason `raw-cache-idb.ts` is the one file that touches IndexedDB for blobs. |
 
 ### Modified
 
 - `src/lib/raw-worker.ts` -- hash, consult the cache, store on miss.
 - `src/lib/storage/kv.ts` -- add `updateDocument(key, fn)`, a get+put inside one
-  transaction. See Concurrency.
-- The Settings page -- usage read-out and Clear button.
+  transaction. See Concurrency. Also, from the F1 review fix, `DatabaseVersionError`:
+  a downgrade -- opening at `DATABASE_VERSION` against a database a newer build
+  already upgraded -- is now a named, distinguishable error rather than a
+  generic one, so `readJson` in `app-storage.ts` can refuse to swallow it into
+  the empty-state fallback the way it does every other read failure.
+- `src/lib/app-storage.ts` -- `readJson` rethrows `DatabaseVersionError` instead
+  of returning the fallback for it.
+- `src/app/init.tsx` -- a startup probe that surfaces `DatabaseVersionError` as
+  a persistent toast (mounted app-wide via the root layout, so every page gets
+  it), and a best-effort `persistStorageBestEffort()` call.
+- The Settings page -- usage and effective-budget read-out, and the Clear
+  button.
 
 ### The storage seam
 
@@ -359,12 +376,32 @@ on a 67 MB TIFF and removes the hazard entirely.
 
 ## Eviction
 
-Budget **2 GB**, fixed. LRU by `lastUsed`, evicting until total is at or under
-budget, never the entry just added. Mirrors `evictDownToBudget` in
-`raw-preview.ts` so both tiers read alike.
+Budget **2 GB nominal, clamped against the origin's real quota.** LRU by
+`lastUsed`, evicting until total is at or under budget, never the entry just
+added. Mirrors `evictDownToBudget` in `raw-preview.ts` so both tiers read
+alike.
+
+Not fixed at 2 GB in practice, and review is why: on a host whose actual
+`navigator.storage.estimate().quota` is smaller than 2 GB, a fixed budget
+means the index never looks full even though the disk already is, so the
+eviction loop above never runs -- writes simply start failing once the real
+quota is hit, with the index accounting none the wiser. The effective budget
+is instead `min(2 GB, 50% of estimate().quota)` when a quota is reported, and
+2 GB unchanged when it isn't (Jest, or a host that declines to answer).
+Settings reports this effective figure, not the nominal one -- see below.
 
 One guard the session tier does not need: a blob larger than the whole budget
 is not cached at all, rather than evicting everything and then itself.
+
+The 50% share, not 100%: this origin also holds presets, settings and run
+history, and a persistent RAW cache that claimed the *entire* quota would
+start evicting only once nothing was left for anything else sharing it.
+
+The app also calls `navigator.storage.persist()` once, best-effort, on
+startup and again on the worker's first cache use. This cache can add up to
+a couple of gigabytes to an origin that had never asked not to be reclaimed
+under storage pressure -- and that pressure does not distinguish the RAW
+cache from the presets sitting next to it in the same database.
 
 ## Reconciliation
 
@@ -400,9 +437,20 @@ Two real cases remain:
 Asymmetric, deliberately:
 
 - A cache **read** failure is treated as a miss, and the frame is converted.
-- A cache **write** failure is logged and swallowed. The conversion already
-  succeeded and the user should get their image whether or not the disk
-  cooperated.
+- A cache **write** failure evicts the LRU entries needed to free roughly what
+  was about to be written, independent of the budget figure, and retries the
+  write once. A failure that survives the retry is logged and swallowed --
+  the conversion already succeeded and the user should get their image
+  whether or not the disk cooperated.
+
+  The retry exists because review found the naive version -- swallow on the
+  first failure, no attempt to make room -- wedges permanently on a host
+  whose real quota is under the clamped budget: the index can sit
+  comfortably under that budget while the store is already full, so nothing
+  ever gets evicted and every write from then on fails the same way. Freeing
+  space unconditionally on a write failure (rather than only when the index
+  itself looks over budget) is what turns that into a slower cache instead
+  of a dead one.
 
 **The cache may never be the reason a conversion fails.**
 
@@ -413,6 +461,14 @@ One row beside the tool versions the page already carries:
 ```
 RAW conversion cache        1.2 GB of 2 GB used     [Clear]
 ```
+
+The right-hand figure is the *effective* budget from "Eviction" above, not
+the nominal 2 GB -- on a host with a smaller quota it reads smaller than
+2 GB, and showing the nominal figure there would just be a different way of
+lying about how much room is actually left. Usage and the effective budget
+are both async (the latter needs a `navigator.storage.estimate()` round
+trip) and are read together, in the same effect, so the row never paints a
+frame pairing real usage against the still-nominal budget or vice versa.
 
 Usage reads the index document directly from the page. Clearing from the page
 is fine: only `createSyncAccessHandle()` is worker-restricted;
@@ -428,8 +484,15 @@ through IndexedDB. Output is a per-host table answering the three questions
 above.
 
 **2. Unit** (Jest, fake `BlobStore`): hit, miss, eviction order, budget guard,
-phantom self-heal, orphan sweep, write-failure swallowed, and a changed tool tag
-causing a miss.
+phantom self-heal, orphan sweep, a changed tool tag causing a miss, and, from
+the F2 review fix, quota-clamped budget resolution and a write failure that
+evicts and retries once (discriminated from budget-gated eviction: a case
+with the index comfortably under budget, where only the unconditional
+failure-path eviction frees anything). From the F3 review fix, a changed
+Emscripten version also causing a miss, alongside the existing commit-change
+case. From the F1 review fix (`storage/kv.ts`, `app-storage.ts`), a downgrade
+open rejecting with `DatabaseVersionError` and `readJson` rethrowing it
+instead of returning the fallback.
 
 **3. Integration**: convert once, request identical bytes again, assert the
 injected converter ran exactly once -- the counting-injection pattern

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -205,7 +205,7 @@ OPFS verdict.
 | Chromium (Playwright, macOS) | true | true | true | 78-103 | true | 84-97 | 115-179 | 93-120 | 3072-4096 MB | 41-66 | none |
 | WKWebView (macOS, Tauri) | needs a local Tauri debug build | -- | -- | -- | -- | -- | -- | -- | -- | -- | not yet run |
 | WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
-| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebKitGTK (Linux, Tauri) | -- (API absent) | false | -- | -- | -- | -- | -- | -- | pending CI | pending CI | `navigator.storage.getDirectory` is not a function -- see `eb0aec8` |
 
 Chromium and WebKit each show a range because the spec was run more than
 once while diagnosing the WebKit result below; the numbers move host-load to
@@ -312,17 +312,20 @@ which is what let CI's WebKit and WebKitGTK runs go green without
 reopening the question this section answered.
 
 **Still needed:** an unloaded rerun of the WebKit case (the current numbers
-are confounded, not negative), plus all three Tauri webviews.
-`e2e-tests/test/specs/storage-probe.e2e.ts` exists, ports the same probe body
-(including the chunked paths) to `browser.execute`, and type-checks
-(`npx tsc --noEmit` from `e2e-tests`), but has not run anywhere -- it needs
-the debug Tauri binary that `wdio.conf.js`'s `onPrepare` builds
-(`npm run tauri build -- --debug --no-bundle --features e2e-driver`), which
-this pass did not produce. WKWebView can run locally afterward with
-`npm run test:e2e:desktop` on macOS; WebView2 and WebKitGTK need the
-`e2e-tests` CI job on its Windows and Ubuntu runners. Until those rows are
-filled in from a host that also passes the 4-byte control, neither the
-backend (A vs. B) nor the write path can be decided -- this section is what
+are confounded, not negative), plus WKWebView and WebView2.
+`e2e-tests/test/specs/storage-probe.e2e.ts` exists and ports the same probe
+body (including the chunked paths) to `browser.execute`; it has since run in
+the `e2e-tests` CI job on the Ubuntu runner, giving the WebKitGTK row above
+(`opfsAvailable: false`), but not yet on Windows or locally on macOS. It
+needs the debug Tauri binary that `wdio.conf.js`'s `onPrepare` builds
+(`npm run tauri build -- --debug --no-bundle --features e2e-driver`). WKWebView
+can run locally with `npm run test:e2e:desktop` on macOS; WebView2 needs the
+`e2e-tests` CI job on its Windows runner. Until those rows are filled in from
+a host that also passes the 4-byte control where OPFS is present, neither the
+backend (A vs. B) nor the write path can be decided from this table alone --
+though the backend question is already settled: two engines report no OPFS
+API at all, which is enough to send this to approach B under the rule stated
+above, independent of what WKWebView and WebView2 still show. This section is what
 the decision needs, not the decision itself.
 
 ## Components

--- a/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
+++ b/docs/superpowers/specs/2026-07-31-opfs-raw-cache-design.md
@@ -184,18 +184,36 @@ for a large OPFS write, and a chunked pass that survives where the
 single-shot one failed would point at the call shape rather than at OPFS
 itself -- see the spec's module docstring.
 
-| Host | opfsAvailable | opfsRoundTrips | opfsWriteMs | opfsChunkedRoundTrips | opfsChunkedWriteMs | opfsSync.writeMs | opfsSyncChunked.writeMs | quota | idbWriteMs | errors |
-|---|---|---|---|---|---|---|---|---|---|---|
-| WebKit (Playwright, macOS) | true | false | -- | inconclusive | -- | -- | -- | 1000 MB | 169-296 | see below -- host-level, not a finding about OPFS |
-| Chromium (Playwright, macOS) | true | true | 78-103 | true | 97 | 115-179 | 120 | 3072-4096 MB | 41-66 | none |
-| WKWebView (macOS, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
-| WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
-| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+It also now runs a **control write** first on every host: 4 bytes, main
+thread, `createWritable`, read back and compared, before anything else is
+attempted. This was added after the WebKit row below was first recorded and
+turned out to be wrong -- see the correction below the table. `controlOk`
+must be `true` before any other cell in that host's row means anything about
+OPFS; the spec's own assertions are ordered the same way, control first, so a
+run that fails the control reports itself as inconclusive rather than as an
+OPFS verdict.
+
+| Host | controlOk | opfsAvailable | opfsRoundTrips | opfsWriteMs | opfsChunkedRoundTrips | opfsChunkedWriteMs | opfsSync.writeMs | opfsSyncChunked.writeMs | quota | idbWriteMs | errors |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| WebKit (Playwright, macOS) | **false** (inferred -- see below) | true | -- (never compared) | -- | -- (never compared) | -- | -- | -- | 1000 MB | 169-296 | `UnknownError: ... out of memory` at `getDirectory()`, before any write -- host-level, not a finding about OPFS |
+| Chromium (Playwright, macOS) | true | true | true | 78-103 | true | 84-97 | 115-179 | 93-120 | 3072-4096 MB | 41-66 | none |
+| WKWebView (macOS, Tauri) | needs a local Tauri debug build | -- | -- | -- | -- | -- | -- | -- | -- | -- | not yet run |
+| WebView2 (Windows, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
+| WebKitGTK (Linux, Tauri) | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI | pending CI |
 
 Chromium and WebKit each show a range because the spec was run more than
 once while diagnosing the WebKit result below; the numbers move host-load to
 host-load but the pass/fail outcome was stable across every Chromium run and
-every WebKit run.
+every WebKit run. Chromium's `controlOk: true` and full round-trip are from
+the most recent run, after the control write and the chunked paths were both
+added -- confirming neither addition regressed the already-passing case.
+
+WebKit's `controlOk` is marked **false (inferred)** rather than measured: the
+control write did not exist as a spec assertion during any of the WebKit runs
+recorded here, but a same-session throwaway diagnostic (a bare 4-byte
+`createWritable` write, described below) failed identically, which is exactly
+what the permanent control write now checks. Not run again to confirm --
+see "Still needed."
 
 **Chromium round-trips cleanly on all four paths, single-shot and chunked,
 main thread and worker.** All four writes -- `createWritable` single-shot,
@@ -204,7 +222,7 @@ main thread and worker.** All four writes -- `createWritable` single-shot,
 This is the one clean chunked-vs-single-shot comparison available so far: the
 chunked writer's code path is correct, and on an engine that already handles
 the single-shot write, chunking neither breaks anything nor buys much
-(97 ms vs. 78-103 ms for `createWritable`; 120 ms vs. 115-179 ms for
+(84-97 ms vs. 78-103 ms for `createWritable`; 93-120 ms vs. 115-179 ms for
 `createSyncAccessHandle` -- see the timing-comparability caveat below before
 reading either pair as a real speed difference).
 
@@ -229,16 +247,24 @@ one are **confounded by host memory pressure, not evidence about WebKit's
 OPFS implementation**. Both are marked accordingly in the table rather than
 left to read as findings.
 
-This is Playwright's bundled WebKit on macOS in an ephemeral profile, not
-WKWebView -- the row the "OPFS fails on any engine -> B" rule actually needs,
-and it needs a result from an unloaded host (CI, or this same machine at
-rest) before it counts as one. If WKWebView fails the same way on a host that
-also fails a 4-byte control write, that is the same confound repeated, not
-independent confirmation. If WKWebView fails while a same-session 4-byte
-control succeeds, that is a real, engine-level finding and the "any engine"
-rule fires. If WKWebView round-trips cleanly, the WebKit-only result does not
-decide anything on its own, since the rule is stated per engine and WebKit is
-not one of the five it names.
+This is Playwright's bundled WebKit on macOS, in an ephemeral profile. The
+task brief's backend decision rule names five engines explicitly -- "WebKit,
+Chromium, WKWebView, WebView2, WebKitGTK" -- and WebKit is the first of them,
+so the rule does apply to this row; the point is not that WebKit falls
+outside it. The point is that this row's **evidence is invalid**, not that
+the rule doesn't reach it: `controlOk: false` means the host could not write
+4 bytes, so nothing this run reports distinguishes "OPFS is broken in
+WebKit" from "this host was thrashing." Applying the brief's "OPFS fails on
+any engine -> approach B" rule to invalid evidence would be deciding the
+architecture on a measurement that was never actually taken -- the run must
+be regathered on an unloaded host (CI, or this same machine at rest, with
+`controlOk: true`) before the rule can be applied to WebKit at all. Once a
+valid WebKit result exists, three outcomes follow directly from the brief's
+rule, independent of what WKWebView separately shows: a valid failure on
+WebKit itself fires "fails on any engine -> B" outright; a valid pass leaves
+the decision to whatever the other four engines show; and a second invalid
+run (`controlOk: false` again) means try again on a different host, not a
+finding either way.
 
 **The write-path timing is not comparable as instrumented, independent of the
 confound above.** `opfsSync.writeMs` brackets only `access.write` + `flush`
@@ -246,7 +272,8 @@ inside the worker, on a freshly allocated all-zero buffer; `opfsWriteMs`
 brackets `write` + `close` on the main thread, on the patterned source buffer.
 Different spans, different payloads. The same gap exists between
 `opfsSyncChunked.writeMs` and `opfsChunkedWriteMs`. None of Chromium's four
-numbers should be fed into the 2x rule under "Write path" above -- a rerun
+numbers should be fed into the brief's write-path rule (`createSyncAccessHandle`
+over `createWritable` only if more than 2x faster on every engine) -- a rerun
 timing the same span over the same bytes would be needed before any pair of
 them means anything.
 

--- a/e2e-tests/test/specs/storage-probe.e2e.ts
+++ b/e2e-tests/test/specs/storage-probe.e2e.ts
@@ -10,6 +10,17 @@
  * `page.evaluate` to `browser.execute` because this suite drives the three
  * Tauri webviews (WKWebView, WebView2, WebKitGTK) that Playwright cannot
  * attach to -- see the module docstring in `e2e-web/playwright.config.ts`.
+ *
+ * A single 67 MB `write()` raised `UnknownError: ... out of memory` on
+ * Playwright's WebKit under a reported 1000 MB quota -- which only indicts
+ * OPFS itself if the failure follows the bytes rather than the call. Both
+ * write paths below therefore run twice: once as one call across the whole
+ * blob, once as 8 MB slices through the same handle. A chunked pass that
+ * survives where the single-shot one didn't points at the call shape, not
+ * the backend. (The same Playwright run also showed the WebKit result can be
+ * confounded by host memory pressure unrelated to OPFS -- see the design
+ * doc's "Probe results" section before reading a WKWebView failure here as
+ * decisive on its own.)
  */
 import assert from "node:assert/strict";
 import { browser } from "@wdio/globals";
@@ -17,6 +28,10 @@ import { describe, it } from "mocha";
 
 /** One converted CR2 frame, near enough. The realistic unit, not a token blob. */
 const BLOB_BYTES = 67 * 1024 * 1024;
+
+/** Slice size for the chunked write paths -- arbitrary but comfortably under
+ * both the whole blob and any single-message size limit a worker might hit. */
+const CHUNK_BYTES = 8 * 1024 * 1024;
 
 describe("storage probe", () => {
   it("OPFS and IndexedDB accept a converted-frame-sized blob", async () => {
@@ -26,35 +41,70 @@ describe("storage probe", () => {
     // IndexedDB.
     await browser.setTimeout({ script: 180_000 });
 
-    const report = await browser.execute(async (size) => {
-      const out: Record<string, unknown> = {};
+    const report = await browser.execute(
+      async (size, chunkBytes) => {
+        const out: Record<string, unknown> = {};
 
-      const estimate = await navigator.storage?.estimate?.();
-      out.quota = estimate?.quota ?? null;
-      out.usage = estimate?.usage ?? null;
+        const estimate = await navigator.storage?.estimate?.();
+        out.quota = estimate?.quota ?? null;
+        out.usage = estimate?.usage ?? null;
 
-      // A recognisable, non-uniform pattern: a run of zeroes would survive a
-      // truncated write and still compare equal.
-      const source = new Uint8Array(size);
-      for (let i = 0; i < size; i += 4096) {
-        source[i] = (i / 4096) % 251;
-      }
+        // A recognisable, non-uniform pattern: a run of zeroes would survive a
+        // truncated write and still compare equal.
+        const source = new Uint8Array(size);
+        for (let i = 0; i < size; i += 4096) {
+          source[i] = (i / 4096) % 251;
+        }
 
-      out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
-      if (out.opfsAvailable) {
-        // Measured inside a dedicated worker, because `createSyncAccessHandle`
-        // exists nowhere else -- which is the whole reason the persistent
-        // tier sits in a worker. Timed against `createWritable` below so the
-        // choice between them is made on numbers rather than on reasoning.
-        const workerSource = `
-          self.onmessage = async (event) => {
-            const size = event.data;
+        // Shared by both `createWritable` passes below: write through
+        // `writeFn`, then read the whole file back and compare it to
+        // `source` at the same three points the worker's own comparison
+        // uses. Factored out so the single-shot and chunked call sites read
+        // as "what differs" rather than repeating the read-back/compare.
+        async function writeAndVerify(
+          root: FileSystemDirectoryHandle,
+          fileName: string,
+          writeFn: (writable: FileSystemWritableFileStream) => Promise<void>
+        ) {
+          const handle = await root.getFileHandle(fileName, { create: true });
+          const writable = await handle.createWritable();
+          const started = performance.now();
+          await writeFn(writable);
+          await writable.close();
+          const writeMs = Math.round(performance.now() - started);
+
+          const readStarted = performance.now();
+          const back = new Uint8Array(
+            await (await handle.getFile()).arrayBuffer()
+          );
+          const readMs = Math.round(performance.now() - readStarted);
+          const roundTrips =
+            back.length === source.length &&
+            back[0] === source[0] &&
+            back[size - 4096] === source[size - 4096];
+
+          await root.removeEntry(fileName);
+          return { readMs, roundTrips, writeMs };
+        }
+
+        out.opfsAvailable =
+          typeof navigator.storage?.getDirectory === "function";
+        if (out.opfsAvailable) {
+          // Measured inside a dedicated worker, because `createSyncAccessHandle`
+          // exists nowhere else -- which is the whole reason the persistent
+          // tier sits in a worker. Timed against `createWritable` below so the
+          // choice between them is made on numbers rather than on reasoning.
+          // Both the single-shot and chunked passes run in this one worker,
+          // back to back, so a fresh handle is used for each rather than
+          // reopening the first.
+          const workerSource = `
+          const CHUNK_BYTES = ${chunkBytes};
+
+          async function writeSingleShot(root, size) {
             try {
-              const root = await navigator.storage.getDirectory();
               const handle = await root.getFileHandle("probe-sync.bin", { create: true });
               if (typeof handle.createSyncAccessHandle !== "function") {
-                self.postMessage({ available: false });
-                return;
+                return { available: false };
               }
               const access = await handle.createSyncAccessHandle();
               const bytes = new Uint8Array(size);
@@ -63,88 +113,169 @@ describe("storage probe", () => {
               access.flush();
               const written = access.getSize();
               access.close();
-              self.postMessage({
+              const result = {
                 available: true,
                 writeMs: Math.round(performance.now() - started),
                 written,
-              });
+              };
               await root.removeEntry("probe-sync.bin");
+              return result;
             } catch (error) {
-              self.postMessage({ available: true, error: String(error) });
+              return { available: true, error: String(error) };
+            }
+          }
+
+          async function writeChunked(root, size) {
+            try {
+              const handle = await root.getFileHandle("probe-sync-chunked.bin", { create: true });
+              if (typeof handle.createSyncAccessHandle !== "function") {
+                return { available: false };
+              }
+              const access = await handle.createSyncAccessHandle();
+              const started = performance.now();
+              for (let position = 0; position < size; position += CHUNK_BYTES) {
+                const chunkSize = Math.min(CHUNK_BYTES, size - position);
+                access.write(new Uint8Array(chunkSize), { at: position });
+              }
+              access.flush();
+              const written = access.getSize();
+              access.close();
+              const result = {
+                available: true,
+                writeMs: Math.round(performance.now() - started),
+                written,
+              };
+              await root.removeEntry("probe-sync-chunked.bin");
+              return result;
+            } catch (error) {
+              return { available: true, error: String(error) };
+            }
+          }
+
+          // A top-level catch too, not just inside each helper: the single
+          // point of failure that would otherwise post nothing at all, and
+          // the caller waits out the full timeout with no idea why.
+          self.onmessage = async (event) => {
+            const size = event.data;
+            try {
+              const root = await navigator.storage.getDirectory();
+              const single = await writeSingleShot(root, size);
+              const chunked = await writeChunked(root, size);
+              try {
+                self.postMessage({ single, chunked });
+              } catch (error) {
+                self.postMessage({ stage: "postMessage", error: String(error) });
+              }
+            } catch (error) {
+              self.postMessage({ stage: "getDirectory", error: String(error) });
             }
           };
         `;
-        const worker = new Worker(
-          URL.createObjectURL(
-            new Blob([workerSource], { type: "text/javascript" })
-          )
-        );
-        out.opfsSync = await new Promise((resolve) => {
-          const timer = setTimeout(
-            () => resolve({ error: "timed out after 60s" }),
-            60_000
+          const worker = new Worker(
+            URL.createObjectURL(
+              new Blob([workerSource], { type: "text/javascript" })
+            )
           );
-          worker.onmessage = (event) => {
-            clearTimeout(timer);
-            resolve(event.data);
-          };
-          worker.postMessage(size);
-        });
-        worker.terminate();
+          // Two full passes over the blob now share this one timeout budget,
+          // so it is double the single-pass figure below rather than the
+          // same one.
+          const workerReport = await new Promise<{
+            single?: Record<string, unknown>;
+            chunked?: Record<string, unknown>;
+            error?: string;
+          }>((resolve) => {
+            const timer = setTimeout(
+              () => resolve({ error: "timed out after 120s" }),
+              120_000
+            );
+            worker.onmessage = (event) => {
+              clearTimeout(timer);
+              resolve(event.data);
+            };
+            worker.postMessage(size);
+          });
+          out.opfsSync = workerReport?.single ?? workerReport;
+          out.opfsSyncChunked = workerReport?.chunked;
+          worker.terminate();
+
+          try {
+            const root = await navigator.storage.getDirectory();
+            const result = await writeAndVerify(root, "probe.bin", (writable) =>
+              writable.write(source)
+            );
+            out.opfsWriteMs = result.writeMs;
+            out.opfsReadMs = result.readMs;
+            out.opfsRoundTrips = result.roundTrips;
+            out.opfsRemoved = true;
+          } catch (error) {
+            out.opfsError = String(error);
+          }
+
+          // Same comparison, chunked: 8 MB slices through one handle rather
+          // than one call across the whole blob. See the module docstring for
+          // why.
+          try {
+            const root = await navigator.storage.getDirectory();
+            const result = await writeAndVerify(
+              root,
+              "probe-chunked.bin",
+              async (writable) => {
+                for (
+                  let position = 0;
+                  position < size;
+                  position += chunkBytes
+                ) {
+                  const slice = source.subarray(
+                    position,
+                    Math.min(position + chunkBytes, size)
+                  );
+                  await writable.write({
+                    data: slice,
+                    position,
+                    type: "write",
+                  });
+                }
+              }
+            );
+            out.opfsChunkedWriteMs = result.writeMs;
+            out.opfsChunkedReadMs = result.readMs;
+            out.opfsChunkedRoundTrips = result.roundTrips;
+            out.opfsChunkedRemoved = true;
+          } catch (error) {
+            out.opfsChunkedError = String(error);
+          }
+        }
 
         try {
-          const root = await navigator.storage.getDirectory();
-          const handle = await root.getFileHandle("probe.bin", {
-            create: true,
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open("probe-db", 1);
+            request.onupgradeneeded = () =>
+              request.result.createObjectStore("blobs");
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
           });
-          const writable = await handle.createWritable();
           const started = performance.now();
-          await writable.write(source);
-          await writable.close();
-          out.opfsWriteMs = Math.round(performance.now() - started);
-
-          const readStarted = performance.now();
-          const back = new Uint8Array(
-            await (await handle.getFile()).arrayBuffer()
-          );
-          out.opfsReadMs = Math.round(performance.now() - readStarted);
-          out.opfsRoundTrips =
-            back.length === source.length &&
-            back[0] === source[0] &&
-            back[size - 4096] === source[size - 4096];
-
-          await root.removeEntry("probe.bin");
-          out.opfsRemoved = true;
+          await new Promise<void>((resolve, reject) => {
+            const transaction = database.transaction("blobs", "readwrite");
+            transaction
+              .objectStore("blobs")
+              .put(source.buffer.slice(0), "probe");
+            transaction.oncomplete = () => resolve();
+            transaction.onabort = () => reject(transaction.error);
+          });
+          out.idbWriteMs = Math.round(performance.now() - started);
+          out.idbRoundTrips = true;
+          database.close();
+          indexedDB.deleteDatabase("probe-db");
         } catch (error) {
-          out.opfsError = String(error);
+          out.idbError = String(error);
         }
-      }
 
-      try {
-        const database = await new Promise<IDBDatabase>((resolve, reject) => {
-          const request = indexedDB.open("probe-db", 1);
-          request.onupgradeneeded = () =>
-            request.result.createObjectStore("blobs");
-          request.onsuccess = () => resolve(request.result);
-          request.onerror = () => reject(request.error);
-        });
-        const started = performance.now();
-        await new Promise<void>((resolve, reject) => {
-          const transaction = database.transaction("blobs", "readwrite");
-          transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
-          transaction.oncomplete = () => resolve();
-          transaction.onabort = () => reject(transaction.error);
-        });
-        out.idbWriteMs = Math.round(performance.now() - started);
-        out.idbRoundTrips = true;
-        database.close();
-        indexedDB.deleteDatabase("probe-db");
-      } catch (error) {
-        out.idbError = String(error);
-      }
-
-      return out;
-    }, BLOB_BYTES);
+        return out;
+      },
+      BLOB_BYTES,
+      CHUNK_BYTES
+    );
 
     // node.js context now -- printed the same way the Playwright probe does,
     // so both hosts' results are grepped out of CI logs the same way.

--- a/e2e-tests/test/specs/storage-probe.e2e.ts
+++ b/e2e-tests/test/specs/storage-probe.e2e.ts
@@ -1,0 +1,172 @@
+/**
+ * Answers #243's open question: does OPFS work where this app runs?
+ *
+ * Not a regression test. It reports a table and asserts only that the
+ * webview did not lie -- bytes written must read back identical. Run it once
+ * per host and record the result in the design doc; it decides whether the
+ * persistent cache stores blobs in OPFS or in IndexedDB.
+ *
+ * Same probe body as `e2e-web/tests/storage-probe.spec.ts`, ported from
+ * `page.evaluate` to `browser.execute` because this suite drives the three
+ * Tauri webviews (WKWebView, WebView2, WebKitGTK) that Playwright cannot
+ * attach to -- see the module docstring in `e2e-web/playwright.config.ts`.
+ */
+import assert from "node:assert/strict";
+import { browser } from "@wdio/globals";
+import { describe, it } from "mocha";
+
+/** One converted CR2 frame, near enough. The realistic unit, not a token blob. */
+const BLOB_BYTES = 67 * 1024 * 1024;
+
+describe("storage probe", () => {
+  it("OPFS and IndexedDB accept a converted-frame-sized blob", async () => {
+    // WebDriver's own script timeout defaults far below what this needs: the
+    // sync-access-handle path alone waits up to 60s internally, on top of
+    // writing and reading 67 MB twice more through createWritable and
+    // IndexedDB.
+    await browser.setTimeout({ script: 180_000 });
+
+    const report = await browser.execute(async (size) => {
+      const out: Record<string, unknown> = {};
+
+      const estimate = await navigator.storage?.estimate?.();
+      out.quota = estimate?.quota ?? null;
+      out.usage = estimate?.usage ?? null;
+
+      // A recognisable, non-uniform pattern: a run of zeroes would survive a
+      // truncated write and still compare equal.
+      const source = new Uint8Array(size);
+      for (let i = 0; i < size; i += 4096) {
+        source[i] = (i / 4096) % 251;
+      }
+
+      out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
+      if (out.opfsAvailable) {
+        // Measured inside a dedicated worker, because `createSyncAccessHandle`
+        // exists nowhere else -- which is the whole reason the persistent
+        // tier sits in a worker. Timed against `createWritable` below so the
+        // choice between them is made on numbers rather than on reasoning.
+        const workerSource = `
+          self.onmessage = async (event) => {
+            const size = event.data;
+            try {
+              const root = await navigator.storage.getDirectory();
+              const handle = await root.getFileHandle("probe-sync.bin", { create: true });
+              if (typeof handle.createSyncAccessHandle !== "function") {
+                self.postMessage({ available: false });
+                return;
+              }
+              const access = await handle.createSyncAccessHandle();
+              const bytes = new Uint8Array(size);
+              const started = performance.now();
+              access.write(bytes, { at: 0 });
+              access.flush();
+              const written = access.getSize();
+              access.close();
+              self.postMessage({
+                available: true,
+                writeMs: Math.round(performance.now() - started),
+                written,
+              });
+              await root.removeEntry("probe-sync.bin");
+            } catch (error) {
+              self.postMessage({ available: true, error: String(error) });
+            }
+          };
+        `;
+        const worker = new Worker(
+          URL.createObjectURL(
+            new Blob([workerSource], { type: "text/javascript" })
+          )
+        );
+        out.opfsSync = await new Promise((resolve) => {
+          const timer = setTimeout(
+            () => resolve({ error: "timed out after 60s" }),
+            60_000
+          );
+          worker.onmessage = (event) => {
+            clearTimeout(timer);
+            resolve(event.data);
+          };
+          worker.postMessage(size);
+        });
+        worker.terminate();
+
+        try {
+          const root = await navigator.storage.getDirectory();
+          const handle = await root.getFileHandle("probe.bin", {
+            create: true,
+          });
+          const writable = await handle.createWritable();
+          const started = performance.now();
+          await writable.write(source);
+          await writable.close();
+          out.opfsWriteMs = Math.round(performance.now() - started);
+
+          const readStarted = performance.now();
+          const back = new Uint8Array(
+            await (await handle.getFile()).arrayBuffer()
+          );
+          out.opfsReadMs = Math.round(performance.now() - readStarted);
+          out.opfsRoundTrips =
+            back.length === source.length &&
+            back[0] === source[0] &&
+            back[size - 4096] === source[size - 4096];
+
+          await root.removeEntry("probe.bin");
+          out.opfsRemoved = true;
+        } catch (error) {
+          out.opfsError = String(error);
+        }
+      }
+
+      try {
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open("probe-db", 1);
+          request.onupgradeneeded = () =>
+            request.result.createObjectStore("blobs");
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        });
+        const started = performance.now();
+        await new Promise<void>((resolve, reject) => {
+          const transaction = database.transaction("blobs", "readwrite");
+          transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
+          transaction.oncomplete = () => resolve();
+          transaction.onabort = () => reject(transaction.error);
+        });
+        out.idbWriteMs = Math.round(performance.now() - started);
+        out.idbRoundTrips = true;
+        database.close();
+        indexedDB.deleteDatabase("probe-db");
+      } catch (error) {
+        out.idbError = String(error);
+      }
+
+      return out;
+    }, BLOB_BYTES);
+
+    // node.js context now -- printed the same way the Playwright probe does,
+    // so both hosts' results are grepped out of CI logs the same way.
+    console.log(
+      `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
+    );
+
+    // Absence fails loudly rather than passing quietly. A green test on a
+    // host with no OPFS would read as "verified" when nothing was verified at
+    // all, and this run exists precisely to find out which hosts those are.
+    // A failure here is a result to record, not a bug to fix.
+    assert.equal(report.opfsAvailable, true, "OPFS is available on this host");
+    assert.equal(
+      report.opfsError,
+      undefined,
+      `OPFS write/read raised nothing: ${report.opfsError}`
+    );
+    assert.equal(report.opfsRoundTrips, true, "OPFS bytes read back identical");
+    assert.equal(
+      report.idbError,
+      undefined,
+      `IndexedDB accepted a 67 MB value: ${report.idbError}`
+    );
+  });
+});

--- a/e2e-tests/test/specs/storage-probe.e2e.ts
+++ b/e2e-tests/test/specs/storage-probe.e2e.ts
@@ -1,10 +1,15 @@
 /**
- * Answers #243's open question: does OPFS work where this app runs?
+ * Answered #243's open question: does OPFS work where this app runs?
  *
- * Not a regression test. It reports a table and asserts only that the
- * webview did not lie -- bytes written must read back identical. Run it once
- * per host and record the result in the design doc; it decides whether the
- * persistent cache stores blobs in OPFS or in IndexedDB.
+ * It found `navigator.storage.getDirectory` absent -- not slow, not
+ * quota-limited, absent -- in WebKit and in WebKitGTK 605.1.15, the webview
+ * Tauri uses on Linux. IndexedDB round-tripped 67 MB on every engine tested,
+ * including both WebKits, so the persistent cache was built on IndexedDB
+ * (`raw-cache-idb.ts`), and that is what this probe now guards: IndexedDB
+ * failing is a real regression, OPFS being missing is not, because nothing
+ * depends on it. OPFS is still measured and printed on every run -- see the
+ * assertions at the bottom -- so a future host that gains OPFS shows up in
+ * the CI log without this spec having to change again.
  *
  * Same probe body as `e2e-web/tests/storage-probe.spec.ts`, ported from
  * `page.evaluate` to `browser.execute` because this suite drives the three
@@ -399,33 +404,50 @@ describe("storage probe", () => {
       `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
     );
 
-    // Absence fails loudly rather than passing quietly. A green test on a
-    // host with no OPFS would read as "verified" when nothing was verified at
-    // all, and this run exists precisely to find out which hosts those are.
-    // A failure here is a result to record, not a bug to fix.
-    assert.equal(report.opfsAvailable, true, "OPFS is available on this host");
-
-    // Checked before the real OPFS assertions, deliberately: if this one
-    // fails, it should be the assertion that fails, so the report reads as
-    // "this run is inconclusive" rather than "OPFS is broken here" -- the
-    // exact conflation that produced a wrong finding on the browser side of
-    // this probe.
-    assert.equal(
-      report.controlOk,
-      true,
-      `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
-    );
-
-    assert.equal(
-      report.opfsError,
-      undefined,
-      `OPFS write/read raised nothing: ${report.opfsError}`
-    );
-    assert.equal(report.opfsRoundTrips, true, "OPFS bytes read back identical");
+    // IndexedDB is the app's real dependency -- see the module docstring --
+    // so this is the assertion that guards the cache. It held on every
+    // engine the probe ever ran against, WebKit and WebKitGTK included, and
+    // if it ever stops holding the cache is broken and CI should say so.
     assert.equal(
       report.idbError,
       undefined,
       `IndexedDB accepted a 67 MB value: ${report.idbError}`
     );
+    assert.equal(
+      report.idbRoundTrips,
+      true,
+      "IndexedDB write transaction completed"
+    );
+
+    // OPFS is recorded, not required: absence is the expected,
+    // already-investigated state on WebKit and WebKitGTK, not a
+    // build-breaking finding. `opfsAvailable` is deliberately not asserted --
+    // see the module docstring -- but the printed report above keeps it
+    // visible so a host that gains OPFS later shows up in the log.
+    if (report.opfsAvailable) {
+      // Checked before the OPFS assertion below, deliberately: if this one
+      // fails, it should be the assertion that fails, so the report reads as
+      // "this run is inconclusive" rather than "OPFS is broken here" -- the
+      // exact conflation that produced a wrong finding on the browser side
+      // of this probe.
+      assert.equal(
+        report.controlOk,
+        true,
+        `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
+      );
+
+      // An engine that claims OPFS and then corrupts data is a real finding
+      // worth failing on -- only OPFS's *absence* is non-fatal now. A raised
+      // error (the memory-pressure case the module docstring describes) is
+      // not asserted directly: `controlOk` above already turned that run
+      // inconclusive rather than a pass or a fail.
+      if (report.opfsError === undefined) {
+        assert.equal(
+          report.opfsRoundTrips,
+          true,
+          "OPFS bytes read back identical"
+        );
+      }
+    }
   });
 });

--- a/e2e-tests/test/specs/storage-probe.e2e.ts
+++ b/e2e-tests/test/specs/storage-probe.e2e.ts
@@ -11,16 +11,35 @@
  * Tauri webviews (WKWebView, WebView2, WebKitGTK) that Playwright cannot
  * attach to -- see the module docstring in `e2e-web/playwright.config.ts`.
  *
+ * The port is not a straight copy, though: `page.evaluate` awaits a returned
+ * promise because it speaks CDP, but `browser.execute` speaks classic
+ * WebDriver's execute-sync endpoint by default, which does not -- only a
+ * BiDi-negotiated session does, and whether Tauri's drivers negotiate BiDi is
+ * unverified. Every `browser.execute` call in `app.e2e.ts` is a synchronous
+ * callback for exactly this reason: on a driver that ignores the returned
+ * promise, an async callback here would return before the probe resolves and
+ * silently produce no measurement -- the precise failure this port exists to
+ * avoid, so it follows the same convention. The callback below is
+ * synchronous; it launches the probe as a page-side IIFE that stashes its
+ * result on a `window` global, and the Node side polls with
+ * `browser.waitUntil`.
+ *
  * A single 67 MB `write()` raised `UnknownError: ... out of memory` on
  * Playwright's WebKit under a reported 1000 MB quota -- which only indicts
  * OPFS itself if the failure follows the bytes rather than the call. Both
  * write paths below therefore run twice: once as one call across the whole
  * blob, once as 8 MB slices through the same handle. A chunked pass that
  * survives where the single-shot one didn't points at the call shape, not
- * the backend. (The same Playwright run also showed the WebKit result can be
- * confounded by host memory pressure unrelated to OPFS -- see the design
- * doc's "Probe results" section before reading a WKWebView failure here as
- * decisive on its own.)
+ * the backend.
+ *
+ * That same WebKit run turned out to be neither of those things: a follow-up
+ * 4-byte write failed with the identical error, on a host that
+ * `memory_pressure` showed was down to double-digit megabytes free. A host
+ * that cannot write 4 bytes cannot tell you whether it can write 67 MB in one
+ * call or eight, so a trivial control write now runs first and gates how the
+ * rest of the report is read -- see the assertions at the bottom, and the
+ * design doc's "Probe results" section for what that meant for the WebKit row
+ * already recorded there.
  */
 import assert from "node:assert/strict";
 import { browser } from "@wdio/globals";
@@ -33,40 +52,64 @@ const BLOB_BYTES = 67 * 1024 * 1024;
  * both the whole blob and any single-message size limit a worker might hit. */
 const CHUNK_BYTES = 8 * 1024 * 1024;
 
+/** Where the page-side IIFE below parks its progress and result, so the Node
+ * side can poll for them with plain, synchronous `browser.execute` calls. */
+interface StorageProbeWindow {
+  __storageProbeDone?: boolean;
+  __storageProbeResult?: Record<string, unknown>;
+}
+
 describe("storage probe", () => {
   it("OPFS and IndexedDB accept a converted-frame-sized blob", async () => {
-    // WebDriver's own script timeout defaults far below what this needs: the
-    // sync-access-handle path alone waits up to 60s internally, on top of
-    // writing and reading 67 MB twice more through createWritable and
-    // IndexedDB.
-    await browser.setTimeout({ script: 180_000 });
+    // Synchronous on purpose -- see the module docstring. This call returns
+    // as soon as the IIFE is launched, not when it finishes.
+    await browser.execute(
+      (size, chunkBytes) => {
+        const w = window as unknown as StorageProbeWindow;
+        w.__storageProbeDone = false;
+        w.__storageProbeResult = undefined;
 
-    const report = await browser.execute(
-      async (size, chunkBytes) => {
-        const out: Record<string, unknown> = {};
-
-        const estimate = await navigator.storage?.estimate?.();
-        out.quota = estimate?.quota ?? null;
-        out.usage = estimate?.usage ?? null;
-
-        // A recognisable, non-uniform pattern: a run of zeroes would survive a
-        // truncated write and still compare equal.
-        const source = new Uint8Array(size);
-        for (let i = 0; i < size; i += 4096) {
-          source[i] = (i / 4096) % 251;
+        // A trivial write that must succeed before the 67 MB numbers
+        // elsewhere in this report are trusted as an OPFS finding.
+        // Discovered the hard way: a host under enough memory pressure
+        // fails a 4-byte write with the exact same error a 67 MB write
+        // produces, at the same `getDirectory()` stage, before either write
+        // is attempted -- indistinguishable from OPFS itself being broken
+        // unless something this small is checked first.
+        async function probeControl(root: FileSystemDirectoryHandle) {
+          try {
+            const handle = await root.getFileHandle("control.bin", {
+              create: true,
+            });
+            const writable = await handle.createWritable();
+            await writable.write(new Uint8Array([1, 2, 3, 4]));
+            await writable.close();
+            const back = new Uint8Array(
+              await (await handle.getFile()).arrayBuffer()
+            );
+            const controlOk = back.length === 4 && back[3] === 4;
+            await root.removeEntry("control.bin");
+            return { controlOk };
+          } catch (error) {
+            return { controlError: String(error), controlOk: false };
+          }
         }
 
         // Shared by both `createWritable` passes below: write through
         // `writeFn`, then read the whole file back and compare it to
         // `source` at the same three points the worker's own comparison
-        // uses. Factored out so the single-shot and chunked call sites read
-        // as "what differs" rather than repeating the read-back/compare.
+        // uses. Factored out so the single-shot and chunked call sites
+        // read as "what differs" rather than repeating the
+        // read-back/compare.
         async function writeAndVerify(
           root: FileSystemDirectoryHandle,
           fileName: string,
+          source: Uint8Array,
           writeFn: (writable: FileSystemWritableFileStream) => Promise<void>
         ) {
-          const handle = await root.getFileHandle(fileName, { create: true });
+          const handle = await root.getFileHandle(fileName, {
+            create: true,
+          });
           const writable = await handle.createWritable();
           const started = performance.now();
           await writeFn(writable);
@@ -81,127 +124,27 @@ describe("storage probe", () => {
           const roundTrips =
             back.length === source.length &&
             back[0] === source[0] &&
-            back[size - 4096] === source[size - 4096];
+            back.at(-4096) === source.at(-4096);
 
           await root.removeEntry(fileName);
           return { readMs, roundTrips, writeMs };
         }
 
-        out.opfsAvailable =
-          typeof navigator.storage?.getDirectory === "function";
-        if (out.opfsAvailable) {
-          // Measured inside a dedicated worker, because `createSyncAccessHandle`
-          // exists nowhere else -- which is the whole reason the persistent
-          // tier sits in a worker. Timed against `createWritable` below so the
-          // choice between them is made on numbers rather than on reasoning.
-          // Both the single-shot and chunked passes run in this one worker,
-          // back to back, so a fresh handle is used for each rather than
-          // reopening the first.
-          const workerSource = `
-          const CHUNK_BYTES = ${chunkBytes};
-
-          async function writeSingleShot(root, size) {
-            try {
-              const handle = await root.getFileHandle("probe-sync.bin", { create: true });
-              if (typeof handle.createSyncAccessHandle !== "function") {
-                return { available: false };
-              }
-              const access = await handle.createSyncAccessHandle();
-              const bytes = new Uint8Array(size);
-              const started = performance.now();
-              access.write(bytes, { at: 0 });
-              access.flush();
-              const written = access.getSize();
-              access.close();
-              const result = {
-                available: true,
-                writeMs: Math.round(performance.now() - started),
-                written,
-              };
-              await root.removeEntry("probe-sync.bin");
-              return result;
-            } catch (error) {
-              return { available: true, error: String(error) };
-            }
-          }
-
-          async function writeChunked(root, size) {
-            try {
-              const handle = await root.getFileHandle("probe-sync-chunked.bin", { create: true });
-              if (typeof handle.createSyncAccessHandle !== "function") {
-                return { available: false };
-              }
-              const access = await handle.createSyncAccessHandle();
-              const started = performance.now();
-              for (let position = 0; position < size; position += CHUNK_BYTES) {
-                const chunkSize = Math.min(CHUNK_BYTES, size - position);
-                access.write(new Uint8Array(chunkSize), { at: position });
-              }
-              access.flush();
-              const written = access.getSize();
-              access.close();
-              const result = {
-                available: true,
-                writeMs: Math.round(performance.now() - started),
-                written,
-              };
-              await root.removeEntry("probe-sync-chunked.bin");
-              return result;
-            } catch (error) {
-              return { available: true, error: String(error) };
-            }
-          }
-
-          // A top-level catch too, not just inside each helper: the single
-          // point of failure that would otherwise post nothing at all, and
-          // the caller waits out the full timeout with no idea why.
-          self.onmessage = async (event) => {
-            const size = event.data;
-            try {
-              const root = await navigator.storage.getDirectory();
-              const single = await writeSingleShot(root, size);
-              const chunked = await writeChunked(root, size);
-              try {
-                self.postMessage({ single, chunked });
-              } catch (error) {
-                self.postMessage({ stage: "postMessage", error: String(error) });
-              }
-            } catch (error) {
-              self.postMessage({ stage: "getDirectory", error: String(error) });
-            }
-          };
-        `;
-          const worker = new Worker(
-            URL.createObjectURL(
-              new Blob([workerSource], { type: "text/javascript" })
-            )
-          );
-          // Two full passes over the blob now share this one timeout budget,
-          // so it is double the single-pass figure below rather than the
-          // same one.
-          const workerReport = await new Promise<{
-            single?: Record<string, unknown>;
-            chunked?: Record<string, unknown>;
-            error?: string;
-          }>((resolve) => {
-            const timer = setTimeout(
-              () => resolve({ error: "timed out after 120s" }),
-              120_000
-            );
-            worker.onmessage = (event) => {
-              clearTimeout(timer);
-              resolve(event.data);
-            };
-            worker.postMessage(size);
-          });
-          out.opfsSync = workerReport?.single ?? workerReport;
-          out.opfsSyncChunked = workerReport?.chunked;
-          worker.terminate();
-
+        // The two `createWritable` passes: single-shot across the whole
+        // blob, then chunked in `chunkBytes` slices through the same
+        // handle. Both go through `writeAndVerify` above; only what each
+        // call writes differs.
+        async function probeMainThread(
+          root: FileSystemDirectoryHandle,
+          source: Uint8Array
+        ) {
+          const out: Record<string, unknown> = {};
           try {
-            const root = await navigator.storage.getDirectory();
-            const result = await writeAndVerify(root, "probe.bin", (writable) =>
-              writable.write(source)
+            const result = await writeAndVerify(
+              root,
+              "probe.bin",
+              source,
+              (writable) => writable.write(source as BufferSource)
             );
             out.opfsWriteMs = result.writeMs;
             out.opfsReadMs = result.readMs;
@@ -211,26 +154,23 @@ describe("storage probe", () => {
             out.opfsError = String(error);
           }
 
-          // Same comparison, chunked: 8 MB slices through one handle rather
-          // than one call across the whole blob. See the module docstring for
-          // why.
           try {
-            const root = await navigator.storage.getDirectory();
             const result = await writeAndVerify(
               root,
               "probe-chunked.bin",
+              source,
               async (writable) => {
                 for (
                   let position = 0;
-                  position < size;
+                  position < source.length;
                   position += chunkBytes
                 ) {
                   const slice = source.subarray(
                     position,
-                    Math.min(position + chunkBytes, size)
+                    Math.min(position + chunkBytes, source.length)
                   );
                   await writable.write({
-                    data: slice,
+                    data: slice as BufferSource,
                     position,
                     type: "write",
                   });
@@ -244,38 +184,214 @@ describe("storage probe", () => {
           } catch (error) {
             out.opfsChunkedError = String(error);
           }
+          return out;
         }
 
-        try {
-          const database = await new Promise<IDBDatabase>((resolve, reject) => {
-            const request = indexedDB.open("probe-db", 1);
-            request.onupgradeneeded = () =>
-              request.result.createObjectStore("blobs");
-            request.onsuccess = () => resolve(request.result);
-            request.onerror = () => reject(request.error);
+        // Measured inside a dedicated worker, because
+        // `createSyncAccessHandle` exists nowhere else -- which is the
+        // whole reason the persistent tier sits in a worker. Timed against
+        // `createWritable` above so the choice between them is made on
+        // numbers rather than on reasoning. Both the single-shot and
+        // chunked passes run in this one worker, back to back, so a fresh
+        // handle is used for each rather than reopening the first.
+        async function probeWorker(blobSize: number) {
+          const workerSource = `
+            const CHUNK_BYTES = ${chunkBytes};
+
+            async function writeSingleShot(root, size) {
+              try {
+                const handle = await root.getFileHandle("probe-sync.bin", { create: true });
+                if (typeof handle.createSyncAccessHandle !== "function") {
+                  return { available: false };
+                }
+                const access = await handle.createSyncAccessHandle();
+                const bytes = new Uint8Array(size);
+                const started = performance.now();
+                access.write(bytes, { at: 0 });
+                access.flush();
+                const written = access.getSize();
+                access.close();
+                const result = {
+                  available: true,
+                  writeMs: Math.round(performance.now() - started),
+                  written,
+                };
+                await root.removeEntry("probe-sync.bin");
+                return result;
+              } catch (error) {
+                return { available: true, error: String(error) };
+              }
+            }
+
+            async function writeChunked(root, size) {
+              try {
+                const handle = await root.getFileHandle("probe-sync-chunked.bin", { create: true });
+                if (typeof handle.createSyncAccessHandle !== "function") {
+                  return { available: false };
+                }
+                const access = await handle.createSyncAccessHandle();
+                const started = performance.now();
+                for (let position = 0; position < size; position += CHUNK_BYTES) {
+                  const chunkSize = Math.min(CHUNK_BYTES, size - position);
+                  access.write(new Uint8Array(chunkSize), { at: position });
+                }
+                access.flush();
+                const written = access.getSize();
+                access.close();
+                const result = {
+                  available: true,
+                  writeMs: Math.round(performance.now() - started),
+                  written,
+                };
+                await root.removeEntry("probe-sync-chunked.bin");
+                return result;
+              } catch (error) {
+                return { available: true, error: String(error) };
+              }
+            }
+
+            // A top-level catch too, not just inside each helper: the
+            // single point of failure that would otherwise post nothing at
+            // all, and the caller waits out the full timeout with no idea
+            // why.
+            self.onmessage = async (event) => {
+              const size = event.data;
+              try {
+                const root = await navigator.storage.getDirectory();
+                const single = await writeSingleShot(root, size);
+                const chunked = await writeChunked(root, size);
+                try {
+                  self.postMessage({ single, chunked });
+                } catch (error) {
+                  self.postMessage({ stage: "postMessage", error: String(error) });
+                }
+              } catch (error) {
+                self.postMessage({ stage: "getDirectory", error: String(error) });
+              }
+            };
+          `;
+          const worker = new Worker(
+            URL.createObjectURL(
+              new Blob([workerSource], { type: "text/javascript" })
+            )
+          );
+          // Two full passes over the blob now share this one timeout
+          // budget, so it is double the single-pass figure below rather
+          // than the same one.
+          const workerReport = await new Promise<{
+            single?: Record<string, unknown>;
+            chunked?: Record<string, unknown>;
+            error?: string;
+          }>((resolve) => {
+            const timer = setTimeout(
+              () => resolve({ error: "timed out after 120s" }),
+              120_000
+            );
+            worker.onmessage = (event) => {
+              clearTimeout(timer);
+              resolve(event.data);
+            };
+            worker.postMessage(blobSize);
           });
-          const started = performance.now();
-          await new Promise<void>((resolve, reject) => {
-            const transaction = database.transaction("blobs", "readwrite");
-            transaction
-              .objectStore("blobs")
-              .put(source.buffer.slice(0), "probe");
-            transaction.oncomplete = () => resolve();
-            transaction.onabort = () => reject(transaction.error);
-          });
-          out.idbWriteMs = Math.round(performance.now() - started);
-          out.idbRoundTrips = true;
-          database.close();
-          indexedDB.deleteDatabase("probe-db");
-        } catch (error) {
-          out.idbError = String(error);
+          worker.terminate();
+          return {
+            chunked: workerReport?.chunked,
+            single: workerReport?.single ?? workerReport,
+          };
         }
 
-        return out;
+        async function probeIndexedDb(source: Uint8Array) {
+          const out: Record<string, unknown> = {};
+          try {
+            const database = await new Promise<IDBDatabase>(
+              (resolve, reject) => {
+                const request = indexedDB.open("probe-db", 1);
+                request.onupgradeneeded = () =>
+                  request.result.createObjectStore("blobs");
+                request.onsuccess = () => resolve(request.result);
+                request.onerror = () => reject(request.error);
+              }
+            );
+            const started = performance.now();
+            await new Promise<void>((resolve, reject) => {
+              const transaction = database.transaction("blobs", "readwrite");
+              transaction
+                .objectStore("blobs")
+                .put(source.buffer.slice(0), "probe");
+              transaction.oncomplete = () => resolve();
+              transaction.onabort = () => reject(transaction.error);
+            });
+            out.idbWriteMs = Math.round(performance.now() - started);
+            out.idbRoundTrips = true;
+            database.close();
+            indexedDB.deleteDatabase("probe-db");
+          } catch (error) {
+            out.idbError = String(error);
+          }
+          return out;
+        }
+
+        // Orchestration only, deliberately: quota, the source buffer, then
+        // one call into each probe above, in the order the design doc's
+        // "Probe results" table lists them.
+        (async () => {
+          const out: Record<string, unknown> = {};
+
+          const estimate = await navigator.storage?.estimate?.();
+          out.quota = estimate?.quota ?? null;
+          out.usage = estimate?.usage ?? null;
+
+          // A recognisable, non-uniform pattern: a run of zeroes would
+          // survive a truncated write and still compare equal.
+          const source = new Uint8Array(size);
+          for (let i = 0; i < size; i += 4096) {
+            source[i] = (i / 4096) % 251;
+          }
+
+          out.opfsAvailable =
+            typeof navigator.storage?.getDirectory === "function";
+          if (out.opfsAvailable) {
+            const root = await navigator.storage.getDirectory();
+            Object.assign(out, await probeControl(root));
+            const workerResult = await probeWorker(size);
+            out.opfsSync = workerResult.single;
+            out.opfsSyncChunked = workerResult.chunked;
+            Object.assign(out, await probeMainThread(root, source));
+          }
+
+          Object.assign(out, await probeIndexedDb(source));
+
+          w.__storageProbeResult = out;
+          w.__storageProbeDone = true;
+        })();
       },
       BLOB_BYTES,
       CHUNK_BYTES
     );
+
+    // Two full OPFS passes plus IndexedDB, so this is generous the same way
+    // the removed `browser.setTimeout({ script })` used to be -- except this
+    // wait is Node-side and polling, not a WebDriver script-execution budget,
+    // so it works the same regardless of what a given driver does with a
+    // returned promise.
+    await browser.waitUntil(
+      async () =>
+        await browser.execute(
+          () =>
+            (window as unknown as StorageProbeWindow).__storageProbeDone ===
+            true
+        ),
+      {
+        interval: 1000,
+        timeout: 180_000,
+        timeoutMsg: "expected the storage probe to finish within 180s",
+      }
+    );
+
+    const report = await browser.execute(
+      () => (window as unknown as StorageProbeWindow).__storageProbeResult
+    );
+    assert.ok(report, "expected the storage probe to have posted a result");
 
     // node.js context now -- printed the same way the Playwright probe does,
     // so both hosts' results are grepped out of CI logs the same way.
@@ -288,6 +404,18 @@ describe("storage probe", () => {
     // all, and this run exists precisely to find out which hosts those are.
     // A failure here is a result to record, not a bug to fix.
     assert.equal(report.opfsAvailable, true, "OPFS is available on this host");
+
+    // Checked before the real OPFS assertions, deliberately: if this one
+    // fails, it should be the assertion that fails, so the report reads as
+    // "this run is inconclusive" rather than "OPFS is broken here" -- the
+    // exact conflation that produced a wrong finding on the browser side of
+    // this probe.
+    assert.equal(
+      report.controlOk,
+      true,
+      `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
+    );
+
     assert.equal(
       report.opfsError,
       undefined,

--- a/e2e-web/package.json
+++ b/e2e-web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "playwright test",
     "test:headed": "playwright test --headed",
+    "bench": "playwright test -c perf.config.ts",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/e2e-web/perf.config.ts
+++ b/e2e-web/perf.config.ts
@@ -1,0 +1,44 @@
+/**
+ * Config for `tests/perf.bench.ts`, kept separate from `playwright.config.ts`.
+ *
+ * Separate for three reasons. The benchmark reports numbers rather than
+ * asserting behaviour, so it must never run as part of the suite. It needs a
+ * `webServer` only when the target is local -- pointing one at a deployed URL
+ * would start a server nothing talks to. And it runs Chromium only: the suite
+ * leads with WebKit because that is the code most users run, but a benchmark
+ * comparing two *hosts* wants one engine held fixed, and mixing them would
+ * confound a ~1.5x engine difference into the hosting comparison.
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4321;
+const TARGET = process.env.TARGET_URL ?? `http://127.0.0.1:${PORT}`;
+const isLocal = TARGET.includes("127.0.0.1") || TARGET.includes("localhost");
+
+export default defineConfig({
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  reporter: [["list"]],
+  // A retry would silently benchmark a warm HTTP cache and report it as a cold
+  // run, which is the one number this file exists to get right.
+  retries: 0,
+  testDir: "./tests",
+  testMatch: /perf\.bench\.ts/,
+  timeout: 600_000,
+  use: { trace: "off", video: "off" },
+  ...(isLocal
+    ? {
+        webServer: {
+          // `next start` cannot serve this build -- `output: "export"` means
+          // there is no server to start. See `playwright.config.ts`.
+          command: `npx serve ../out -l ${PORT}`,
+          reuseExistingServer: true,
+          timeout: 60_000,
+          url: `http://127.0.0.1:${PORT}/home-page`,
+        },
+      }
+    : {}),
+  workers: 1,
+});

--- a/e2e-web/tests/perf.bench.ts
+++ b/e2e-web/tests/perf.bench.ts
@@ -44,11 +44,11 @@ const FRAMES = Number(process.env.FRAMES ?? cr2Files.length);
 const RUN_TIMEOUT = 280_000;
 
 interface Req {
-  url: string;
-  status: number;
   bytes: number;
   ms: number;
   startedAt: number;
+  status: number;
+  url: string;
 }
 
 test(`${MODE} against ${TARGET}`, async ({ page }) => {
@@ -156,37 +156,37 @@ test(`${MODE} against ${TARGET}`, async ({ page }) => {
     list.reduce((total, r) => total + pick(r), 0);
 
   const report = {
-    target: TARGET,
-    mode: MODE,
-    work: runLabel,
     coldLoadMs,
-    warmLoadMs,
+    mode: MODE,
     nav,
-    runMs,
     requests: {
-      total: requests.length,
       duringRun: requests.length - requestsBeforeRun,
+      total: requests.length,
+      totalBytes: sum(requests, (r) => r.bytes),
       wasm: wasmRequests.length,
       wasmBytes: sum(wasmRequests, (r) => r.bytes),
       wasmTotalMs: Math.round(sum(wasmRequests, (r) => r.ms)),
-      totalBytes: sum(requests, (r) => r.bytes),
     },
+    runMs,
     slowestRequests: [...requests]
       .sort((a, b) => b.ms - a.ms)
       .slice(0, 15)
       .map((r) => ({
-        ms: Math.round(r.ms),
         kb: Math.round(r.bytes / 1024),
+        ms: Math.round(r.ms),
         url: r.url.replace(TARGET, ""),
       })),
+    target: TARGET,
+    warmLoadMs,
     // One line per tool load. More than one entry per tool would mean the
     // compiled-module cache in `wasm-runner.ts` is not holding.
     wasmRequestDetail: wasmRequests.map((r) => ({
       at: r.startedAt,
-      ms: Math.round(r.ms),
       kb: Math.round(r.bytes / 1024),
+      ms: Math.round(r.ms),
       url: r.url.split("/").pop(),
     })),
+    work: runLabel,
   };
 
   process.stdout.write(

--- a/e2e-web/tests/perf.bench.ts
+++ b/e2e-web/tests/perf.bench.ts
@@ -116,6 +116,7 @@ test(`${MODE} against ${TARGET}`, async ({ page }) => {
   // --- The work itself -----------------------------------------------------
   let runMs: number;
   let runLabel: string;
+  let secondImportMs: number | undefined;
 
   if (MODE === "cr2") {
     // The completion signal is the `<canvas>` each thumbnail appends once it
@@ -136,6 +137,20 @@ test(`${MODE} against ${TARGET}`, async ({ page }) => {
     ).toHaveCount(FRAMES, { timeout: RUN_TIMEOUT });
     runMs = Date.now() - runStart;
     runLabel = `import ${FRAMES} RAW frames to thumbnails`;
+
+    // The point of #243, measured rather than asserted: reload, re-import the
+    // same frames, and the conversion should not happen again. Same files, so
+    // the content hash matches; a new tab, so the session tier is empty and
+    // only the persistent tier can produce the saving.
+    await page.reload({ waitUntil: "load" });
+    const secondStart = Date.now();
+    await loadCr2Frames(page, FRAMES);
+    await expect(
+      page.locator(
+        '[data-testid="image-set-preview"] .generic-image-container canvas'
+      )
+    ).toHaveCount(FRAMES, { timeout: RUN_TIMEOUT });
+    secondImportMs = Date.now() - secondStart;
   } else {
     await loadJpegBracket(page);
     await configureRun(page);
@@ -168,6 +183,7 @@ test(`${MODE} against ${TARGET}`, async ({ page }) => {
       wasmTotalMs: Math.round(sum(wasmRequests, (r) => r.ms)),
     },
     runMs,
+    secondImportMs,
     slowestRequests: [...requests]
       .sort((a, b) => b.ms - a.ms)
       .slice(0, 15)

--- a/e2e-web/tests/perf.bench.ts
+++ b/e2e-web/tests/perf.bench.ts
@@ -140,8 +140,10 @@ test(`${MODE} against ${TARGET}`, async ({ page }) => {
 
     // The point of #243, measured rather than asserted: reload, re-import the
     // same frames, and the conversion should not happen again. Same files, so
-    // the content hash matches; a new tab, so the session tier is empty and
-    // only the persistent tier can produce the saving.
+    // the content hash matches; a reload discards the JS realm, so
+    // raw-preview.ts's module-level session cache and the RAW worker both
+    // start fresh -- leaving the persistent tier as the only possible source
+    // of a saving.
     await page.reload({ waitUntil: "load" });
     const secondStart = Date.now();
     await loadCr2Frames(page, FRAMES);

--- a/e2e-web/tests/perf.bench.ts
+++ b/e2e-web/tests/perf.bench.ts
@@ -1,0 +1,195 @@
+/**
+ * Benchmarks the web build against itself, served from two places.
+ *
+ * This exists because "the deployed site feels slower than the local build" is
+ * not a question inspection can answer. The deployed static export and `../out`
+ * are the same bytes, so any difference has to be delivery -- and the only way
+ * to size delivery against compute is to run the same bracket through both and
+ * measure. It is not part of the suite: it asserts almost nothing and reports
+ * numbers instead, so it belongs on its own config and its own command.
+ *
+ * Run it through `perf.config.ts`, once per target:
+ *
+ *   npm --prefix e2e-web run bench                    # local, JPEG
+ *   MODE=cr2 npm --prefix e2e-web run bench           # local, RAW import
+ *   TARGET_URL=https://example.com npm --prefix e2e-web run bench
+ *
+ * Requests are counted through `page.on(...)` rather than the page's own
+ * Resource Timing, because the pipeline and RAW converters fetch their `.wasm`
+ * from inside a Worker and a worker's entries never land on the page's
+ * performance timeline. The browser's network stack sees all of them.
+ *
+ * Reported timings are only comparable between targets measured the same way.
+ * In particular, an agent sandbox or corporate proxy inflates every remote
+ * fetch while leaving `127.0.0.1` untouched, which fakes exactly the result
+ * this benchmark exists to test for. Check `HTTP_PROXY`/`HTTPS_PROXY` are unset
+ * before believing a deployed number.
+ */
+
+import { expect, test } from "@playwright/test";
+import {
+  configureRun,
+  cr2Files,
+  generate,
+  jpegFiles,
+  loadCr2Frames,
+  loadJpegBracket,
+} from "./support";
+
+const TARGET = process.env.TARGET_URL ?? "http://127.0.0.1:4321";
+/** "jpeg" measures a full generate; "cr2" measures RAW import to thumbnails. */
+const MODE = process.env.MODE === "cr2" ? "cr2" : "jpeg";
+/** RAW frames to import. Fewer is faster; the default is the whole bracket. */
+const FRAMES = Number(process.env.FRAMES ?? cr2Files.length);
+const RUN_TIMEOUT = 280_000;
+
+interface Req {
+  url: string;
+  status: number;
+  bytes: number;
+  ms: number;
+  startedAt: number;
+}
+
+test(`${MODE} against ${TARGET}`, async ({ page }) => {
+  // A benchmark that measured an empty fixture directory would report a very
+  // fast run rather than a failure, so the inputs are checked before anything
+  // is timed.
+  expect(jpegFiles.length, "JPEG fixtures").toBeGreaterThan(0);
+  expect(cr2Files.length, "CR2 fixtures").toBeGreaterThan(0);
+  expect(FRAMES, "FRAMES").toBeGreaterThan(0);
+
+  const requests: Req[] = [];
+  const t0 = Date.now();
+
+  page.on("requestfinished", async (request) => {
+    const timing = request.timing();
+    let status = 0;
+    let bytes = 0;
+    try {
+      const response = await request.response();
+      if (response) {
+        status = response.status();
+        bytes = (await response.request().sizes()).responseBodySize;
+      }
+    } catch {
+      // A request torn down with the page; not interesting for timings.
+    }
+    requests.push({
+      bytes,
+      ms: timing.responseEnd - timing.requestStart,
+      startedAt: Date.now() - t0,
+      status,
+      url: request.url(),
+    });
+  });
+
+  // --- Cold load -----------------------------------------------------------
+  const coldStart = Date.now();
+  await page.goto(`${TARGET}/home-page`, { waitUntil: "load" });
+  const coldLoadMs = Date.now() - coldStart;
+
+  const nav = await page.evaluate(() => {
+    const entry = performance.getEntriesByType(
+      "navigation"
+    )[0] as PerformanceNavigationTiming;
+    const paints = performance.getEntriesByType("paint");
+    return {
+      domContentLoaded: Math.round(
+        entry.domContentLoadedEventEnd - entry.startTime
+      ),
+      firstContentfulPaint: Math.round(
+        paints.find((p) => p.name === "first-contentful-paint")?.startTime ?? -1
+      ),
+      loadEvent: Math.round(entry.loadEventEnd - entry.startTime),
+      ttfb: Math.round(entry.responseStart - entry.startTime),
+    };
+  });
+
+  // --- Warm load (same context, so the HTTP cache is populated) ------------
+  const warmStart = Date.now();
+  await page.reload({ waitUntil: "load" });
+  const warmLoadMs = Date.now() - warmStart;
+
+  const requestsBeforeRun = requests.length;
+
+  // --- The work itself -----------------------------------------------------
+  let runMs: number;
+  let runLabel: string;
+
+  if (MODE === "cr2") {
+    // The completion signal is the `<canvas>` each thumbnail appends once it
+    // has converted *and* decoded, NOT the container div. `TiffImage` fires
+    // `rawToTiff` from a `useMemo` and Suspends only the inner pixel view, so
+    // the divs `loadCr2Frames` waits for mount in about 150 ms -- long before
+    // any demosaic finishes. Counting them measured nothing at all: an earlier
+    // draft of this file reported a 269 ms import of ten 21.7 MB frames with
+    // zero `/wasm/` requests, because it exited before conversion had begun.
+    // See the module docstring on `pipeline.spec.ts`, which documents the same
+    // trap for the responsiveness test.
+    const runStart = Date.now();
+    await loadCr2Frames(page, FRAMES);
+    await expect(
+      page.locator(
+        '[data-testid="image-set-preview"] .generic-image-container canvas'
+      )
+    ).toHaveCount(FRAMES, { timeout: RUN_TIMEOUT });
+    runMs = Date.now() - runStart;
+    runLabel = `import ${FRAMES} RAW frames to thumbnails`;
+  } else {
+    await loadJpegBracket(page);
+    await configureRun(page);
+
+    const downloads: string[] = [];
+    page.on("download", (d) => downloads.push(d.suggestedFilename()));
+
+    const runStart = Date.now();
+    await generate(page);
+    await expect.poll(() => downloads.length, { timeout: RUN_TIMEOUT }).toBe(2);
+    runMs = Date.now() - runStart;
+    runLabel = `generate from ${jpegFiles.length} JPEG frames`;
+  }
+
+  // --- Report --------------------------------------------------------------
+  const wasmRequests = requests.filter((r) => r.url.includes("/wasm/"));
+  const sum = (list: Req[], pick: (r: Req) => number) =>
+    list.reduce((total, r) => total + pick(r), 0);
+
+  const report = {
+    target: TARGET,
+    mode: MODE,
+    work: runLabel,
+    coldLoadMs,
+    warmLoadMs,
+    nav,
+    runMs,
+    requests: {
+      total: requests.length,
+      duringRun: requests.length - requestsBeforeRun,
+      wasm: wasmRequests.length,
+      wasmBytes: sum(wasmRequests, (r) => r.bytes),
+      wasmTotalMs: Math.round(sum(wasmRequests, (r) => r.ms)),
+      totalBytes: sum(requests, (r) => r.bytes),
+    },
+    slowestRequests: [...requests]
+      .sort((a, b) => b.ms - a.ms)
+      .slice(0, 15)
+      .map((r) => ({
+        ms: Math.round(r.ms),
+        kb: Math.round(r.bytes / 1024),
+        url: r.url.replace(TARGET, ""),
+      })),
+    // One line per tool load. More than one entry per tool would mean the
+    // compiled-module cache in `wasm-runner.ts` is not holding.
+    wasmRequestDetail: wasmRequests.map((r) => ({
+      at: r.startedAt,
+      ms: Math.round(r.ms),
+      kb: Math.round(r.bytes / 1024),
+      url: r.url.split("/").pop(),
+    })),
+  };
+
+  process.stdout.write(
+    `\n===PERF_JSON===\n${JSON.stringify(report, null, 2)}\n===END===\n`
+  );
+});

--- a/e2e-web/tests/storage-probe.spec.ts
+++ b/e2e-web/tests/storage-probe.spec.ts
@@ -5,46 +5,59 @@
  * did not lie -- bytes written must read back identical. Run it once per host
  * and record the result in the design doc; it decides whether the persistent
  * cache stores blobs in OPFS or in IndexedDB.
+ *
+ * A single 67 MB `write()` raised `UnknownError: ... out of memory` on
+ * WebKit under a reported 1000 MB quota -- which only indicts OPFS itself if
+ * the failure follows the bytes rather than the call. Both write paths below
+ * therefore run twice: once as one call across the whole blob, once as 8 MB
+ * slices through the same handle. A chunked pass that survives where the
+ * single-shot one didn't points at the call shape, not the backend.
  */
 import { expect, test } from "@playwright/test";
 
 /** One converted CR2 frame, near enough. The realistic unit, not a token blob. */
 const BLOB_BYTES = 67 * 1024 * 1024;
 
+/** Slice size for the chunked write paths -- arbitrary but comfortably under
+ * both the whole blob and any single-message size limit a worker might hit. */
+const CHUNK_BYTES = 8 * 1024 * 1024;
+
 test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
   page,
 }) => {
   await page.goto("/home-page");
 
-  const report = await page.evaluate(async (size) => {
-    const out: Record<string, unknown> = {};
+  const report = await page.evaluate(
+    async ({ size, chunkBytes }) => {
+      const out: Record<string, unknown> = {};
 
-    const estimate = await navigator.storage?.estimate?.();
-    out.quota = estimate?.quota ?? null;
-    out.usage = estimate?.usage ?? null;
+      const estimate = await navigator.storage?.estimate?.();
+      out.quota = estimate?.quota ?? null;
+      out.usage = estimate?.usage ?? null;
 
-    // A recognisable, non-uniform pattern: a run of zeroes would survive a
-    // truncated write and still compare equal.
-    const source = new Uint8Array(size);
-    for (let i = 0; i < size; i += 4096) {
-      source[i] = (i / 4096) % 251;
-    }
+      // A recognisable, non-uniform pattern: a run of zeroes would survive a
+      // truncated write and still compare equal.
+      const source = new Uint8Array(size);
+      for (let i = 0; i < size; i += 4096) {
+        source[i] = (i / 4096) % 251;
+      }
 
-    out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
-    if (out.opfsAvailable) {
-      // Measured inside a dedicated worker, because `createSyncAccessHandle`
-      // exists nowhere else -- which is the whole reason the persistent tier
-      // sits in a worker. Timed against `createWritable` below so the choice
-      // between them is made on numbers rather than on reasoning.
-      const workerSource = `
-        self.onmessage = async (event) => {
-          const size = event.data;
+      out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
+      if (out.opfsAvailable) {
+        // Measured inside a dedicated worker, because `createSyncAccessHandle`
+        // exists nowhere else -- which is the whole reason the persistent tier
+        // sits in a worker. Timed against `createWritable` below so the choice
+        // between them is made on numbers rather than on reasoning. Both the
+        // single-shot and chunked passes run in this one worker, back to back,
+        // so a fresh handle is used for each rather than reopening the first.
+        const workerSource = `
+        const CHUNK_BYTES = ${chunkBytes};
+
+        async function writeSingleShot(root, size) {
           try {
-            const root = await navigator.storage.getDirectory();
             const handle = await root.getFileHandle("probe-sync.bin", { create: true });
             if (typeof handle.createSyncAccessHandle !== "function") {
-              self.postMessage({ available: false });
-              return;
+              return { available: false };
             }
             const access = await handle.createSyncAccessHandle();
             const bytes = new Uint8Array(size);
@@ -53,86 +66,183 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
             access.flush();
             const written = access.getSize();
             access.close();
-            self.postMessage({
+            const result = {
               available: true,
               writeMs: Math.round(performance.now() - started),
               written,
-            });
+            };
             await root.removeEntry("probe-sync.bin");
+            return result;
           } catch (error) {
-            self.postMessage({ available: true, error: String(error) });
+            return { available: true, error: String(error) };
+          }
+        }
+
+        async function writeChunked(root, size) {
+          try {
+            const handle = await root.getFileHandle("probe-sync-chunked.bin", { create: true });
+            if (typeof handle.createSyncAccessHandle !== "function") {
+              return { available: false };
+            }
+            const access = await handle.createSyncAccessHandle();
+            const started = performance.now();
+            for (let position = 0; position < size; position += CHUNK_BYTES) {
+              const chunkSize = Math.min(CHUNK_BYTES, size - position);
+              access.write(new Uint8Array(chunkSize), { at: position });
+            }
+            access.flush();
+            const written = access.getSize();
+            access.close();
+            const result = {
+              available: true,
+              writeMs: Math.round(performance.now() - started),
+              written,
+            };
+            await root.removeEntry("probe-sync-chunked.bin");
+            return result;
+          } catch (error) {
+            return { available: true, error: String(error) };
+          }
+        }
+
+        // A top-level catch too, not just inside each helper: the single
+        // point of failure that would otherwise post nothing at all, and the
+        // caller waits out the full timeout with no idea why. Tagged with a
+        // stage, because "UnknownError" alone does not say whether it came
+        // from opening the root directory, structured-cloning the result, or
+        // (if the per-helper catches somehow missed it) a write itself.
+        self.onmessage = async (event) => {
+          const size = event.data;
+          try {
+            const root = await navigator.storage.getDirectory();
+            const single = await writeSingleShot(root, size);
+            const chunked = await writeChunked(root, size);
+            try {
+              self.postMessage({ single, chunked });
+            } catch (error) {
+              self.postMessage({ stage: "postMessage", error: String(error) });
+            }
+          } catch (error) {
+            self.postMessage({ stage: "getDirectory", error: String(error) });
           }
         };
       `;
-      const worker = new Worker(
-        URL.createObjectURL(
-          new Blob([workerSource], { type: "text/javascript" })
-        )
-      );
-      out.opfsSync = await new Promise((resolve) => {
-        const timer = setTimeout(
-          () => resolve({ error: "timed out after 60s" }),
-          60_000
+        const worker = new Worker(
+          URL.createObjectURL(
+            new Blob([workerSource], { type: "text/javascript" })
+          )
         );
-        worker.onmessage = (event) => {
-          clearTimeout(timer);
-          resolve(event.data);
-        };
-        worker.postMessage(size);
-      });
-      worker.terminate();
+        // Two full passes over the blob now share this one timeout budget, so
+        // it is double the single-pass figure below rather than the same one.
+        const workerReport = await new Promise<{
+          single?: Record<string, unknown>;
+          chunked?: Record<string, unknown>;
+          error?: string;
+        }>((resolve) => {
+          const timer = setTimeout(
+            () => resolve({ error: "timed out after 120s" }),
+            120_000
+          );
+          worker.onmessage = (event) => {
+            clearTimeout(timer);
+            resolve(event.data);
+          };
+          worker.postMessage(size);
+        });
+        out.opfsSync = workerReport?.single ?? workerReport;
+        out.opfsSyncChunked = workerReport?.chunked;
+        worker.terminate();
+
+        try {
+          const root = await navigator.storage.getDirectory();
+          const handle = await root.getFileHandle("probe.bin", {
+            create: true,
+          });
+          const writable = await handle.createWritable();
+          const started = performance.now();
+          await writable.write(source);
+          await writable.close();
+          out.opfsWriteMs = Math.round(performance.now() - started);
+
+          const readStarted = performance.now();
+          const back = new Uint8Array(
+            await (await handle.getFile()).arrayBuffer()
+          );
+          out.opfsReadMs = Math.round(performance.now() - readStarted);
+          out.opfsRoundTrips =
+            back.length === source.length &&
+            back[0] === source[0] &&
+            back[size - 4096] === source[size - 4096];
+
+          await root.removeEntry("probe.bin");
+          out.opfsRemoved = true;
+        } catch (error) {
+          out.opfsError = String(error);
+        }
+
+        // Same comparison, chunked: 8 MB slices through one handle rather than
+        // one call across the whole blob. See the module docstring for why.
+        try {
+          const root = await navigator.storage.getDirectory();
+          const handle = await root.getFileHandle("probe-chunked.bin", {
+            create: true,
+          });
+          const writable = await handle.createWritable();
+          const started = performance.now();
+          for (let position = 0; position < size; position += chunkBytes) {
+            const slice = source.subarray(
+              position,
+              Math.min(position + chunkBytes, size)
+            );
+            await writable.write({ data: slice, position, type: "write" });
+          }
+          await writable.close();
+          out.opfsChunkedWriteMs = Math.round(performance.now() - started);
+
+          const readStarted = performance.now();
+          const back = new Uint8Array(
+            await (await handle.getFile()).arrayBuffer()
+          );
+          out.opfsChunkedReadMs = Math.round(performance.now() - readStarted);
+          out.opfsChunkedRoundTrips =
+            back.length === source.length &&
+            back[0] === source[0] &&
+            back[size - 4096] === source[size - 4096];
+
+          await root.removeEntry("probe-chunked.bin");
+          out.opfsChunkedRemoved = true;
+        } catch (error) {
+          out.opfsChunkedError = String(error);
+        }
+      }
 
       try {
-        const root = await navigator.storage.getDirectory();
-        const handle = await root.getFileHandle("probe.bin", { create: true });
-        const writable = await handle.createWritable();
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open("probe-db", 1);
+          request.onupgradeneeded = () =>
+            request.result.createObjectStore("blobs");
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        });
         const started = performance.now();
-        await writable.write(source);
-        await writable.close();
-        out.opfsWriteMs = Math.round(performance.now() - started);
-
-        const readStarted = performance.now();
-        const back = new Uint8Array(
-          await (await handle.getFile()).arrayBuffer()
-        );
-        out.opfsReadMs = Math.round(performance.now() - readStarted);
-        out.opfsRoundTrips =
-          back.length === source.length &&
-          back[0] === source[0] &&
-          back[size - 4096] === source[size - 4096];
-
-        await root.removeEntry("probe.bin");
-        out.opfsRemoved = true;
+        await new Promise<void>((resolve, reject) => {
+          const transaction = database.transaction("blobs", "readwrite");
+          transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
+          transaction.oncomplete = () => resolve();
+          transaction.onabort = () => reject(transaction.error);
+        });
+        out.idbWriteMs = Math.round(performance.now() - started);
+        out.idbRoundTrips = true;
+        database.close();
+        indexedDB.deleteDatabase("probe-db");
       } catch (error) {
-        out.opfsError = String(error);
+        out.idbError = String(error);
       }
-    }
 
-    try {
-      const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open("probe-db", 1);
-        request.onupgradeneeded = () =>
-          request.result.createObjectStore("blobs");
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-      });
-      const started = performance.now();
-      await new Promise<void>((resolve, reject) => {
-        const transaction = database.transaction("blobs", "readwrite");
-        transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
-        transaction.oncomplete = () => resolve();
-        transaction.onabort = () => reject(transaction.error);
-      });
-      out.idbWriteMs = Math.round(performance.now() - started);
-      out.idbRoundTrips = true;
-      database.close();
-      indexedDB.deleteDatabase("probe-db");
-    } catch (error) {
-      out.idbError = String(error);
-    }
-
-    return out;
-  }, BLOB_BYTES);
+      return out;
+    },
+    { chunkBytes: CHUNK_BYTES, size: BLOB_BYTES }
+  );
 
   process.stdout.write(
     `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`

--- a/e2e-web/tests/storage-probe.spec.ts
+++ b/e2e-web/tests/storage-probe.spec.ts
@@ -12,6 +12,13 @@
  * therefore run twice: once as one call across the whole blob, once as 8 MB
  * slices through the same handle. A chunked pass that survives where the
  * single-shot one didn't points at the call shape, not the backend.
+ *
+ * That same WebKit run turned out to be neither of those things: a follow-up
+ * 4-byte write failed with the identical error, on a host that `memory_pressure`
+ * showed was down to double-digit megabytes free. A host that cannot write 4
+ * bytes cannot tell you whether it can write 67 MB in one call or eight, so a
+ * trivial control write now runs first and gates how the rest of the report
+ * is read -- see the assertions at the bottom.
  */
 import { expect, test } from "@playwright/test";
 
@@ -44,6 +51,31 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
 
       out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
       if (out.opfsAvailable) {
+        // A trivial write that must succeed before the 67 MB numbers below
+        // are trusted as an OPFS finding. Discovered the hard way: a host
+        // under enough memory pressure fails a 4-byte write with the exact
+        // same error a 67 MB write produces, at the same
+        // `getDirectory()` stage, before either write is attempted --
+        // indistinguishable from OPFS itself being broken unless something
+        // this small is checked first.
+        try {
+          const root = await navigator.storage.getDirectory();
+          const handle = await root.getFileHandle("control.bin", {
+            create: true,
+          });
+          const writable = await handle.createWritable();
+          await writable.write(new Uint8Array([1, 2, 3, 4]));
+          await writable.close();
+          const back = new Uint8Array(
+            await (await handle.getFile()).arrayBuffer()
+          );
+          out.controlOk = back.length === 4 && back[3] === 4;
+          await root.removeEntry("control.bin");
+        } catch (error) {
+          out.controlOk = false;
+          out.controlError = String(error);
+        }
+
         // Measured inside a dedicated worker, because `createSyncAccessHandle`
         // exists nowhere else -- which is the whole reason the persistent tier
         // sits in a worker. Timed against `createWritable` below so the choice
@@ -253,6 +285,17 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
   // and this run exists precisely to find out which hosts those are. A failure
   // here is a result to record, not a bug to fix.
   expect(report.opfsAvailable, "OPFS is available on this host").toBe(true);
+
+  // Checked before the real OPFS assertions, deliberately: if this one fails,
+  // it should be the assertion that fails, so the report reads as "this run
+  // is inconclusive" rather than "OPFS is broken here" -- the exact
+  // conflation that produced a wrong finding on the first pass through this
+  // spec.
+  expect(
+    report.controlOk,
+    `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
+  ).toBe(true);
+
   expect(report.opfsError, "OPFS write/read raised nothing").toBeUndefined();
   expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
   expect(report.idbError, "IndexedDB accepted a 67 MB value").toBeUndefined();

--- a/e2e-web/tests/storage-probe.spec.ts
+++ b/e2e-web/tests/storage-probe.spec.ts
@@ -1,10 +1,15 @@
 /**
- * Answers #243's open question: does OPFS work where this app runs?
+ * Answered #243's open question: does OPFS work where this app runs?
  *
- * Not a regression test. It reports a table and asserts only that the browser
- * did not lie -- bytes written must read back identical. Run it once per host
- * and record the result in the design doc; it decides whether the persistent
- * cache stores blobs in OPFS or in IndexedDB.
+ * It found `navigator.storage.getDirectory` absent -- not slow, not
+ * quota-limited, absent -- in WebKit and in WebKitGTK 605.1.15, the webview
+ * Tauri uses on Linux. IndexedDB round-tripped 67 MB on every engine tested,
+ * including both WebKits, so the persistent cache was built on IndexedDB
+ * (`raw-cache-idb.ts`), and that is what this probe now guards: IndexedDB
+ * failing is a real regression, OPFS being missing is not, because nothing
+ * depends on it. OPFS is still measured and printed on every run -- see the
+ * assertions at the bottom -- so a future host that gains OPFS shows up in
+ * the CI log without this spec having to change again.
  *
  * A single 67 MB `write()` raised `UnknownError: ... out of memory` on
  * WebKit under a reported 1000 MB quota -- which only indicts OPFS itself if
@@ -280,23 +285,40 @@ test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
     `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
   );
 
-  // Absence fails loudly rather than passing quietly. A green test on a host
-  // with no OPFS would read as "verified" when nothing was verified at all,
-  // and this run exists precisely to find out which hosts those are. A failure
-  // here is a result to record, not a bug to fix.
-  expect(report.opfsAvailable, "OPFS is available on this host").toBe(true);
-
-  // Checked before the real OPFS assertions, deliberately: if this one fails,
-  // it should be the assertion that fails, so the report reads as "this run
-  // is inconclusive" rather than "OPFS is broken here" -- the exact
-  // conflation that produced a wrong finding on the first pass through this
-  // spec.
-  expect(
-    report.controlOk,
-    `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
-  ).toBe(true);
-
-  expect(report.opfsError, "OPFS write/read raised nothing").toBeUndefined();
-  expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
+  // IndexedDB is the app's real dependency -- see the module docstring -- so
+  // this is the assertion that guards the cache. It held on every engine the
+  // probe ever ran against, WebKit and WebKitGTK included, and if it ever
+  // stops holding the cache is broken and CI should say so.
   expect(report.idbError, "IndexedDB accepted a 67 MB value").toBeUndefined();
+  expect(report.idbRoundTrips, "IndexedDB write transaction completed").toBe(
+    true
+  );
+
+  // OPFS is recorded, not required: absence is the expected, already-
+  // investigated state on WebKit and WebKitGTK, not a build-breaking finding.
+  // `opfsAvailable` is deliberately not asserted -- see the module docstring
+  // -- but the printed report above keeps it visible so a host that gains
+  // OPFS later shows up in the log.
+  if (report.opfsAvailable) {
+    // Checked before the OPFS assertion below, deliberately: if this one
+    // fails, it should be the assertion that fails, so the report reads as
+    // "this run is inconclusive" rather than "OPFS is broken here" -- the
+    // exact conflation that produced a wrong finding on the first pass
+    // through this spec.
+    expect(
+      report.controlOk,
+      `host-level OPFS control write must succeed before the numbers below mean anything about OPFS (control error: ${report.controlError}). A failure here means this run is inconclusive, not a negative finding -- retry on an unloaded host.`
+    ).toBe(true);
+
+    // An engine that claims OPFS and then corrupts data is a real finding
+    // worth failing on -- only OPFS's *absence* is non-fatal now. A raised
+    // error (the memory-pressure case the module docstring describes) is not
+    // asserted directly: `controlOk` above already turned that run
+    // inconclusive rather than a pass or a fail.
+    if (report.opfsError === undefined) {
+      expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(
+        true
+      );
+    }
+  }
 });

--- a/e2e-web/tests/storage-probe.spec.ts
+++ b/e2e-web/tests/storage-probe.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Answers #243's open question: does OPFS work where this app runs?
+ *
+ * Not a regression test. It reports a table and asserts only that the browser
+ * did not lie -- bytes written must read back identical. Run it once per host
+ * and record the result in the design doc; it decides whether the persistent
+ * cache stores blobs in OPFS or in IndexedDB.
+ */
+import { expect, test } from "@playwright/test";
+
+/** One converted CR2 frame, near enough. The realistic unit, not a token blob. */
+const BLOB_BYTES = 67 * 1024 * 1024;
+
+test("OPFS and IndexedDB accept a converted-frame-sized blob", async ({
+  page,
+}) => {
+  await page.goto("/home-page");
+
+  const report = await page.evaluate(async (size) => {
+    const out: Record<string, unknown> = {};
+
+    const estimate = await navigator.storage?.estimate?.();
+    out.quota = estimate?.quota ?? null;
+    out.usage = estimate?.usage ?? null;
+
+    // A recognisable, non-uniform pattern: a run of zeroes would survive a
+    // truncated write and still compare equal.
+    const source = new Uint8Array(size);
+    for (let i = 0; i < size; i += 4096) {
+      source[i] = (i / 4096) % 251;
+    }
+
+    out.opfsAvailable = typeof navigator.storage?.getDirectory === "function";
+    if (out.opfsAvailable) {
+      // Measured inside a dedicated worker, because `createSyncAccessHandle`
+      // exists nowhere else -- which is the whole reason the persistent tier
+      // sits in a worker. Timed against `createWritable` below so the choice
+      // between them is made on numbers rather than on reasoning.
+      const workerSource = `
+        self.onmessage = async (event) => {
+          const size = event.data;
+          try {
+            const root = await navigator.storage.getDirectory();
+            const handle = await root.getFileHandle("probe-sync.bin", { create: true });
+            if (typeof handle.createSyncAccessHandle !== "function") {
+              self.postMessage({ available: false });
+              return;
+            }
+            const access = await handle.createSyncAccessHandle();
+            const bytes = new Uint8Array(size);
+            const started = performance.now();
+            access.write(bytes, { at: 0 });
+            access.flush();
+            const written = access.getSize();
+            access.close();
+            self.postMessage({
+              available: true,
+              writeMs: Math.round(performance.now() - started),
+              written,
+            });
+            await root.removeEntry("probe-sync.bin");
+          } catch (error) {
+            self.postMessage({ available: true, error: String(error) });
+          }
+        };
+      `;
+      const worker = new Worker(
+        URL.createObjectURL(
+          new Blob([workerSource], { type: "text/javascript" })
+        )
+      );
+      out.opfsSync = await new Promise((resolve) => {
+        const timer = setTimeout(
+          () => resolve({ error: "timed out after 60s" }),
+          60_000
+        );
+        worker.onmessage = (event) => {
+          clearTimeout(timer);
+          resolve(event.data);
+        };
+        worker.postMessage(size);
+      });
+      worker.terminate();
+
+      try {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle("probe.bin", { create: true });
+        const writable = await handle.createWritable();
+        const started = performance.now();
+        await writable.write(source);
+        await writable.close();
+        out.opfsWriteMs = Math.round(performance.now() - started);
+
+        const readStarted = performance.now();
+        const back = new Uint8Array(
+          await (await handle.getFile()).arrayBuffer()
+        );
+        out.opfsReadMs = Math.round(performance.now() - readStarted);
+        out.opfsRoundTrips =
+          back.length === source.length &&
+          back[0] === source[0] &&
+          back[size - 4096] === source[size - 4096];
+
+        await root.removeEntry("probe.bin");
+        out.opfsRemoved = true;
+      } catch (error) {
+        out.opfsError = String(error);
+      }
+    }
+
+    try {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open("probe-db", 1);
+        request.onupgradeneeded = () =>
+          request.result.createObjectStore("blobs");
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const started = performance.now();
+      await new Promise<void>((resolve, reject) => {
+        const transaction = database.transaction("blobs", "readwrite");
+        transaction.objectStore("blobs").put(source.buffer.slice(0), "probe");
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error);
+      });
+      out.idbWriteMs = Math.round(performance.now() - started);
+      out.idbRoundTrips = true;
+      database.close();
+      indexedDB.deleteDatabase("probe-db");
+    } catch (error) {
+      out.idbError = String(error);
+    }
+
+    return out;
+  }, BLOB_BYTES);
+
+  process.stdout.write(
+    `\n===STORAGE_PROBE===\n${JSON.stringify(report, null, 2)}\n===END===\n`
+  );
+
+  // Absence fails loudly rather than passing quietly. A green test on a host
+  // with no OPFS would read as "verified" when nothing was verified at all,
+  // and this run exists precisely to find out which hosts those are. A failure
+  // here is a result to record, not a bug to fix.
+  expect(report.opfsAvailable, "OPFS is available on this host").toBe(true);
+  expect(report.opfsError, "OPFS write/read raised nothing").toBeUndefined();
+  expect(report.opfsRoundTrips, "OPFS bytes read back identical").toBe(true);
+  expect(report.idbError, "IndexedDB accepted a 67 MB value").toBeUndefined();
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -21,6 +21,14 @@ const { TextDecoder, TextEncoder } = require("node:util");
 global.TextEncoder = global.TextEncoder || TextEncoder;
 global.TextDecoder = global.TextDecoder || TextDecoder;
 
+// jsdom does not implement structuredClone, which fake-indexeddb uses to
+// clone values into and out of the store, the same way a browser's real
+// IndexedDB does. v8's own serializer round-trip clones the same set of
+// types the structured clone algorithm does, so it stands in faithfully.
+const v8 = require("node:v8");
+global.structuredClone =
+  global.structuredClone || ((value) => v8.deserialize(v8.serialize(value)));
+
 // jsdom exposes crypto but not crypto.subtle, which preset hashing uses.
 const { webcrypto } = require("node:crypto");
 if (!globalThis.crypto?.subtle) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@types/react": "19.1.8",
         "@types/react-dom": "19.1.6",
         "@types/three": "^0.175.0",
+        "fake-indexeddb": "^6.2.5",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "tailwindcss": "^4.1.16",
@@ -7827,6 +7828,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "@types/three": "^0.175.0",
+    "fake-indexeddb": "^6.2.5",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "tailwindcss": "^4.1.16",

--- a/src/app/init.tsx
+++ b/src/app/init.tsx
@@ -12,6 +12,8 @@ import type React from "react";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { isTauri, platformName } from "@/lib/host/env";
+import { persistStorageBestEffort } from "@/lib/raw-cache-quota";
+import { DatabaseVersionError, getDocument } from "@/lib/storage/kv";
 import { useSettingsStore } from "./stores/settings-store";
 
 // Debug flag to enable console logging
@@ -34,6 +36,45 @@ const Initialization: React.FC = () => {
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: app-startup sequencing logic; restructuring risks behavior changes that can't be verified without exercising the actual Tauri startup path.
     const initialize = async () => {
       try {
+        // F1: opening the database at all is what can fail permanently -- a
+        // rolled-back web deploy, a browser still serving an old bundle from
+        // its HTTP cache, or a reinstalled older desktop build can each leave
+        // this browser holding data a *newer* build wrote, which IndexedDB
+        // refuses to open at a lower version. Left undetected, every read
+        // this app makes afterwards fails the same way and, via
+        // `app-storage.ts`'s `readJson`, renders as an empty app -- no
+        // presets, no settings, no run history -- with nothing to explain
+        // why. Probed once here, unconditionally (not gated on `isTauri()`
+        // the way the migration below is; a plain browser reload needs this
+        // exactly as much as a desktop reinstall), because this component is
+        // the one thing mounted on every page.
+        try {
+          await getDocument("__startup-probe__");
+        } catch (error) {
+          if (error instanceof DatabaseVersionError) {
+            // Not dismissed on a timer: the underlying data is untouched, but
+            // nothing in this app works correctly until the user reloads or
+            // updates, so the message should stay until they act rather than
+            // vanish the way a normal error toast would.
+            toast.error(error.message, { duration: Number.POSITIVE_INFINITY });
+          }
+          // Any other open failure is left to whichever storage read actually
+          // hits it -- an `onblocked` race with another tab is transient in a
+          // way a version mismatch is not, and every caller already has its
+          // own handling for "storage didn't work this time."
+        }
+
+        // F2: best-effort and fire-and-forget. The persistent RAW cache can
+        // add up to a couple of gigabytes to this origin (`raw-cache.ts`),
+        // and an origin that has never asked not to be reclaimed is a more
+        // attractive target for the browser's storage-pressure eviction --
+        // presets and settings included, not just those blobs. Also called
+        // from `raw-worker.ts` on first use; kept here too because
+        // `persist()`, unlike `estimate()`, has a history of being
+        // unavailable from a worker on some engines, and this call costs
+        // nothing extra if the worker's succeeds first.
+        persistStorageBestEffort();
+
         // Presets and run history moved from JSON files under the app config
         // directory into IndexedDB, so one implementation serves the desktop
         // app and the browser build. Existing users have real presets and real

--- a/src/app/settings-page/page.tsx
+++ b/src/app/settings-page/page.tsx
@@ -128,12 +128,19 @@ export default function SettingsPage() {
     const cache = createRawCache({ store: idbBlobStore() });
     try {
       await cache.clear();
-      setCacheBytes(await cache.usage());
       toast.success("RAW conversion cache cleared");
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not clear the cache"
       );
+    } finally {
+      // Re-read on both paths: a partial failure still changes what's on
+      // disk, so the figure shown must match reality rather than the last
+      // success -- otherwise an error toast sits next to a stale number.
+      await cache
+        .usage()
+        .then(setCacheBytes)
+        .catch(() => undefined);
     }
   };
 
@@ -404,7 +411,6 @@ export default function SettingsPage() {
                 </div>
                 <button
                   className="rounded bg-secondary px-2 py-1 font-semibold text-secondary-foreground hover:bg-secondary/80"
-                  disabled={cacheBytes === 0}
                   onClick={handleClearCache}
                   type="button"
                 >

--- a/src/app/settings-page/page.tsx
+++ b/src/app/settings-page/page.tsx
@@ -15,6 +15,7 @@
  */
 "use client";
 
+import prettyBytes from "pretty-bytes";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -28,6 +29,8 @@ import {
 import { appInfo, canWriteToChosenDirectory } from "@/lib/host/env";
 import { openExternal } from "@/lib/host/open-external";
 import { pickOutputDirectory } from "@/lib/host/pick";
+import { BUDGET_BYTES, createRawCache } from "@/lib/raw-cache";
+import { blobStoreAvailable, idbBlobStore } from "@/lib/raw-cache-idb";
 import { useSettingsStore } from "../stores/settings-store";
 import SettingsButtonBar from "./settings-button-bar";
 
@@ -55,6 +58,9 @@ export default function SettingsPage() {
   // first render happens at build time where there is no window to ask.
   const [canChooseOutput, setCanChooseOutput] = useState(true);
   const [toolsError, setToolsError] = useState<string | null>(null);
+  // Null distinguishes "no persistent tier on this host" from "empty cache",
+  // since the row below hides on null and would misleadingly read 0 B on 0.
+  const [cacheBytes, setCacheBytes] = useState<number | null>(null);
   useEffect(() => {
     /**
      * Retrieves app name, app version, and tauri version from Tauri API
@@ -77,6 +83,15 @@ export default function SettingsPage() {
       .catch((error: unknown) => {
         setToolsError(error instanceof Error ? error.message : String(error));
       });
+
+    // Absent on a host without IndexedDB, where there is no persistent tier to
+    // report. Zero would claim an empty cache rather than no cache.
+    if (blobStoreAvailable()) {
+      createRawCache({ store: idbBlobStore() })
+        .usage()
+        .then(setCacheBytes)
+        .catch(() => setCacheBytes(null));
+    }
   }, []);
 
   // Update local settings when global settings change
@@ -106,6 +121,20 @@ export default function SettingsPage() {
   const handleUpdatePath = (id: string, path: string) => {
     setLocalSettings({ ...localSettings, [id]: path });
     setSaveDisabled(false); // Enable the save button since changes were made
+  };
+
+  /** Empties the persistent RAW cache and re-reads its size. */
+  const handleClearCache = async () => {
+    const cache = createRawCache({ store: idbBlobStore() });
+    try {
+      await cache.clear();
+      setCacheBytes(await cache.usage());
+      toast.success("RAW conversion cache cleared");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not clear the cache"
+      );
+    }
   };
 
   /**
@@ -356,6 +385,34 @@ export default function SettingsPage() {
               .
             </p>
           </div>
+
+          {/* Its own card rather than folded into "About this build": a
+              clearable disk cache is not part of what the build is made of,
+              and interposing it there would sit between the tool versions
+              and the GPL notice, which the comment above needs adjacent to
+              the tools it documents. */}
+          {cacheBytes !== null && (
+            <div className="rounded-lg border border-border p-5">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <h2 className="font-bold text-xl">RAW conversion cache</h2>
+                  <p className="mt-1 text-muted-foreground text-sm">
+                    {prettyBytes(cacheBytes)} of {prettyBytes(BUDGET_BYTES)}{" "}
+                    used. Converted frames are reused instead of demosaiced
+                    again.
+                  </p>
+                </div>
+                <button
+                  className="rounded bg-secondary px-2 py-1 font-semibold text-secondary-foreground hover:bg-secondary/80"
+                  disabled={cacheBytes === 0}
+                  onClick={handleClearCache}
+                  type="button"
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </main>
 

--- a/src/app/settings-page/page.tsx
+++ b/src/app/settings-page/page.tsx
@@ -31,6 +31,7 @@ import { openExternal } from "@/lib/host/open-external";
 import { pickOutputDirectory } from "@/lib/host/pick";
 import { BUDGET_BYTES, createRawCache } from "@/lib/raw-cache";
 import { blobStoreAvailable, idbBlobStore } from "@/lib/raw-cache-idb";
+import { estimateQuotaBytes } from "@/lib/raw-cache-quota";
 import { useSettingsStore } from "../stores/settings-store";
 import SettingsButtonBar from "./settings-button-bar";
 
@@ -61,6 +62,13 @@ export default function SettingsPage() {
   // Null distinguishes "no persistent tier on this host" from "empty cache",
   // since the row below hides on null and would misleadingly read 0 B on 0.
   const [cacheBytes, setCacheBytes] = useState<number | null>(null);
+  // F2: never actually painted -- the row above is gated on `cacheBytes !==
+  // null`, and the effect below sets both this and `cacheBytes` together
+  // from the same `Promise.all` resolution, so there is no frame where one
+  // is real and the other is still this initial value. Set to BUDGET_BYTES
+  // anyway rather than 0 or null: it is a harmless placeholder for the
+  // instant before that effect runs, not a figure this component ever shows.
+  const [cacheBudget, setCacheBudget] = useState<number>(BUDGET_BYTES);
   useEffect(() => {
     /**
      * Retrieves app name, app version, and tauri version from Tauri API
@@ -87,9 +95,19 @@ export default function SettingsPage() {
     // Absent on a host without IndexedDB, where there is no persistent tier to
     // report. Zero would claim an empty cache rather than no cache.
     if (blobStoreAvailable()) {
-      createRawCache({ store: idbBlobStore() })
-        .usage()
-        .then(setCacheBytes)
+      const cache = createRawCache({
+        estimateQuota: estimateQuotaBytes,
+        store: idbBlobStore(),
+      });
+      // Read together and set together: usage and budget are two independent
+      // promises, and setting one before the other resolves would paint a
+      // frame reporting real usage against the still-nominal budget (or vice
+      // versa) -- back to reporting a number this row doesn't mean.
+      Promise.all([cache.usage(), cache.budget()])
+        .then(([bytes, effectiveBudget]) => {
+          setCacheBytes(bytes);
+          setCacheBudget(effectiveBudget);
+        })
         .catch(() => setCacheBytes(null));
     }
   }, []);
@@ -125,7 +143,10 @@ export default function SettingsPage() {
 
   /** Empties the persistent RAW cache and re-reads its size. */
   const handleClearCache = async () => {
-    const cache = createRawCache({ store: idbBlobStore() });
+    const cache = createRawCache({
+      estimateQuota: estimateQuotaBytes,
+      store: idbBlobStore(),
+    });
     try {
       await cache.clear();
       toast.success("RAW conversion cache cleared");
@@ -404,7 +425,7 @@ export default function SettingsPage() {
                 <div>
                   <h2 className="font-bold text-xl">RAW conversion cache</h2>
                   <p className="mt-1 text-muted-foreground text-sm">
-                    {prettyBytes(cacheBytes)} of {prettyBytes(BUDGET_BYTES)}{" "}
+                    {prettyBytes(cacheBytes)} of {prettyBytes(cacheBudget)}{" "}
                     used. Converted frames are reused instead of demosaiced
                     again.
                   </p>

--- a/src/lib/app-storage.ts
+++ b/src/lib/app-storage.ts
@@ -13,7 +13,7 @@
  * separate, in `storage/migrate-tauri-files.ts`, and runs on desktop only.
  */
 
-import { getDocument, putDocument } from "./storage/kv";
+import { DatabaseVersionError, getDocument, putDocument } from "./storage/kv";
 
 /** Bumped only when a stored shape changes incompatibly. */
 export const STORAGE_VERSION = 1;
@@ -23,6 +23,14 @@ export const STORAGE_VERSION = 1;
  *
  * History and presets are records, not state the app depends on, so a corrupt
  * or future-versioned document must never stop the app from starting.
+ *
+ * One exception: `DatabaseVersionError` is not "corrupt or unreadable", it is
+ * "the data is intact and this build is the one that's behind." Falling back
+ * to empty for that case is how a rolled-back deploy or a stale HTTP-cached
+ * bundle would render as "you have no presets, no settings, no run history"
+ * with nothing telling the user their data is still there. Rethrowing instead
+ * gives a caller the chance to say so -- see `app/init.tsx`'s startup probe,
+ * which is what actually shows it.
  */
 export async function readJson<T>(key: string, fallback: T): Promise<T> {
   try {
@@ -31,7 +39,10 @@ export async function readJson<T>(key: string, fallback: T): Promise<T> {
       return fallback;
     }
     return stored as T;
-  } catch {
+  } catch (error) {
+    if (error instanceof DatabaseVersionError) {
+      throw error;
+    }
     return fallback;
   }
 }

--- a/src/lib/hash.test.ts
+++ b/src/lib/hash.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import { sha256Hex } from "./hash";
+
+const HEX_DIGEST = /^[0-9a-f]{64}$/;
+
+describe("sha256Hex", () => {
+  it("returns the known digest of the empty input", async () => {
+    expect(await sha256Hex(new Uint8Array())).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+
+  it("returns 64 lowercase hex characters", async () => {
+    const digest = await sha256Hex(new Uint8Array([1, 2, 3]));
+    expect(digest).toMatch(HEX_DIGEST);
+  });
+
+  it("distinguishes different bytes", async () => {
+    expect(await sha256Hex(new Uint8Array([1]))).not.toBe(
+      await sha256Hex(new Uint8Array([2]))
+    );
+  });
+});

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,15 @@
+/**
+ * Content hashing, in its own module so a worker can use it.
+ *
+ * This lived in `presets.ts`, which imports a React config provider. Importing
+ * that into `raw-worker.ts` would pull React into the worker bundle for the
+ * sake of one twelve-line function.
+ */
+
+/** Lowercase hex SHA-256. `crypto.subtle` is polyfilled for tests in jest.setup.js. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,7 +1,11 @@
 import type { pipelineConfig } from "@/app/home-page/(pipeline-configuration)/config-provider";
 import { readJson, writeJson } from "./app-storage";
+// biome-ignore lint/style/noExportedImports: the module uses this internally and re-exports for backward compatibility
+import { sha256Hex } from "./hash";
 import { deleteFile, fileKeys, putFile } from "./storage/kv";
 import { presetPath, storedKey } from "./vfs";
+
+export { sha256Hex };
 
 /**
  * Reads a source calibration file.
@@ -74,13 +78,6 @@ export function presetId(name: string): string {
     .replace(NON_SLUG, "-")
     .replace(EDGE_DASHES, "");
   return slug || "preset";
-}
-
-export async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 /**

--- a/src/lib/raw-cache-idb.test.ts
+++ b/src/lib/raw-cache-idb.test.ts
@@ -47,28 +47,51 @@ describe("the IndexedDB blob store", () => {
   it("stores a view of a larger buffer without dragging the whole buffer in", async () => {
     // The defect `putFile` documents: a subarray carries its parent's buffer,
     // so storing the view rather than a slice would persist far more than was
-    // asked for. Asserting on the *read-back value* would not catch this --
-    // IndexedDB's structured clone preserves a view's offset and length over
-    // the cloned buffer, so `read()`'s `new Uint8Array(stored)` would come
-    // back `[3, 4, 5]` either way, view or slice. What a bad implementation
-    // gets wrong is how much gets **stored**: an 8-byte buffer instead of the
-    // 3 bytes asked for. Read the raw record directly, bypassing `read()`'s
-    // conversion, to check the size that actually landed in the database.
+    // asked for. Two things must both hold for a correct write, and a naive
+    // "forgot to slice" bug (`store.put(bytes, key)`, storing the Uint8Array
+    // itself) breaks neither on its own:
+    //
+    //  - The read-back *value* is `[3, 4, 5]` either way. Structured clone
+    //    reconstructs a view with the same offset and length it was given,
+    //    so `read()`'s `new Uint8Array(stored)` looks identical from a
+    //    stored slice or a stored view -- `.byteLength` on a view reflects
+    //    the view's length, not its retained backing buffer.
+    //  - `stored?.byteLength` alone is not enough either: a stored *view*
+    //    that happens to be exactly 3 bytes would also pass a bare
+    //    `byteLength === 3` check while still being the wrong kind of
+    //    record and still retaining the 8-byte buffer behind it.
+    //
+    // What actually distinguishes a correct write is that the record is a
+    // **plain `ArrayBuffer`** of length 3, not a view over something larger.
+    // Read the raw record directly, bypassing `read()`'s conversion, to
+    // check both.
     const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
     await idbBlobStore().write("view", backing.subarray(2, 5));
 
     const stored = await rawBlobRecord("view");
-    expect(stored?.byteLength).toBe(3);
+    // `instanceof ArrayBuffer` is not reliable here: fake-indexeddb's clone
+    // reconstructs the value in a different realm, so a genuinely correct
+    // ArrayBuffer record fails `instanceof` against this file's global
+    // `ArrayBuffer` too. `Object.prototype.toString` and `ArrayBuffer.isView`
+    // read an object's internal slot rather than walking its prototype
+    // chain, so both stay accurate across realms -- verified by hand: a
+    // stored `ArrayBuffer` reports `"[object ArrayBuffer]"` and
+    // `isView() === false`, a stored `Uint8Array` reports
+    // `"[object Uint8Array]"` and `isView() === true`, regardless of realm.
+    expect(Object.prototype.toString.call(stored)).toBe("[object ArrayBuffer]");
+    expect(ArrayBuffer.isView(stored)).toBe(false);
+    expect((stored as ArrayBuffer).byteLength).toBe(3);
   });
 });
 
 /**
  * Reads a blob record straight off the store, without `read()`'s
  * `new Uint8Array(stored)` conversion, so a test can inspect what was
- * actually persisted rather than what a correctly-shaped read would produce
- * from either a correct or a defective write.
+ * actually persisted -- including its *type*, not just a value shaped like
+ * the one `read()` would have produced from either a correct or a defective
+ * write.
  */
-function rawBlobRecord(key: string): Promise<ArrayBuffer | undefined> {
+function rawBlobRecord(key: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     // Same database and store `kv.ts` opens; hardcoded because this reaches
     // underneath that module's API on purpose, to see what it actually wrote.
@@ -81,7 +104,7 @@ function rawBlobRecord(key: string): Promise<ArrayBuffer | undefined> {
         .get(key);
       read.onsuccess = () => {
         database.close();
-        resolve(read.result as ArrayBuffer | undefined);
+        resolve(read.result);
       };
       read.onerror = () => {
         database.close();

--- a/src/lib/raw-cache-idb.test.ts
+++ b/src/lib/raw-cache-idb.test.ts
@@ -1,0 +1,57 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { idbBlobStore } from "./raw-cache-idb";
+
+describe("the IndexedDB blob store", () => {
+  beforeEach(async () => {
+    const store = idbBlobStore();
+    for (const key of await store.keys()) {
+      // biome-ignore lint/performance/noAwaitInLoops: clearing fake-indexeddb between tests; order doesn't matter but a shared store does
+      await store.remove(key);
+    }
+  });
+
+  it("round-trips bytes through write and read", async () => {
+    const store = idbBlobStore();
+    await store.write("a", new Uint8Array([1, 2, 3]));
+    expect(Array.from((await store.read("a")) ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("returns undefined for a key that was never written", async () => {
+    expect(await idbBlobStore().read("absent")).toBeUndefined();
+  });
+
+  it("overwrites an existing key rather than appending", async () => {
+    const store = idbBlobStore();
+    await store.write("a", new Uint8Array([1, 2, 3]));
+    await store.write("a", new Uint8Array([9]));
+    expect(Array.from((await store.read("a")) ?? [])).toEqual([9]);
+  });
+
+  it("lists and removes keys", async () => {
+    const store = idbBlobStore();
+    await store.write("a", new Uint8Array([1]));
+    await store.write("b", new Uint8Array([2]));
+    expect((await store.keys()).toSorted((a, b) => a.localeCompare(b))).toEqual(
+      ["a", "b"]
+    );
+
+    await store.remove("a");
+    expect(await store.keys()).toEqual(["b"]);
+  });
+
+  it("swallows a removal of something absent", async () => {
+    await expect(idbBlobStore().remove("absent")).resolves.toBeUndefined();
+  });
+
+  it("stores a view of a larger buffer without dragging the whole buffer in", async () => {
+    // The defect `putFile` documents: a subarray carries its parent's buffer,
+    // so storing the view rather than a slice would persist far more than was
+    // asked for -- and read back the wrong bytes.
+    const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    await idbBlobStore().write("view", backing.subarray(2, 5));
+    expect(Array.from((await idbBlobStore().read("view")) ?? [])).toEqual([
+      3, 4, 5,
+    ]);
+  });
+});

--- a/src/lib/raw-cache-idb.test.ts
+++ b/src/lib/raw-cache-idb.test.ts
@@ -47,11 +47,47 @@ describe("the IndexedDB blob store", () => {
   it("stores a view of a larger buffer without dragging the whole buffer in", async () => {
     // The defect `putFile` documents: a subarray carries its parent's buffer,
     // so storing the view rather than a slice would persist far more than was
-    // asked for -- and read back the wrong bytes.
+    // asked for. Asserting on the *read-back value* would not catch this --
+    // IndexedDB's structured clone preserves a view's offset and length over
+    // the cloned buffer, so `read()`'s `new Uint8Array(stored)` would come
+    // back `[3, 4, 5]` either way, view or slice. What a bad implementation
+    // gets wrong is how much gets **stored**: an 8-byte buffer instead of the
+    // 3 bytes asked for. Read the raw record directly, bypassing `read()`'s
+    // conversion, to check the size that actually landed in the database.
     const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
     await idbBlobStore().write("view", backing.subarray(2, 5));
-    expect(Array.from((await idbBlobStore().read("view")) ?? [])).toEqual([
-      3, 4, 5,
-    ]);
+
+    const stored = await rawBlobRecord("view");
+    expect(stored?.byteLength).toBe(3);
   });
 });
+
+/**
+ * Reads a blob record straight off the store, without `read()`'s
+ * `new Uint8Array(stored)` conversion, so a test can inspect what was
+ * actually persisted rather than what a correctly-shaped read would produce
+ * from either a correct or a defective write.
+ */
+function rawBlobRecord(key: string): Promise<ArrayBuffer | undefined> {
+  return new Promise((resolve, reject) => {
+    // Same database and store `kv.ts` opens; hardcoded because this reaches
+    // underneath that module's API on purpose, to see what it actually wrote.
+    const request = indexedDB.open("hdri-calibration", 2);
+    request.onsuccess = () => {
+      const database = request.result;
+      const read = database
+        .transaction("blobs", "readonly")
+        .objectStore("blobs")
+        .get(key);
+      read.onsuccess = () => {
+        database.close();
+        resolve(read.result as ArrayBuffer | undefined);
+      };
+      read.onerror = () => {
+        database.close();
+        reject(read.error);
+      };
+    };
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/src/lib/raw-cache-idb.ts
+++ b/src/lib/raw-cache-idb.ts
@@ -1,0 +1,48 @@
+/**
+ * IndexedDB backing for the persistent RAW cache.
+ *
+ * IndexedDB rather than OPFS, and that was measured rather than assumed.
+ * #243 specified OPFS for its `createSyncAccessHandle` fast path; the probe in
+ * `e2e-web/tests/storage-probe.spec.ts` found `navigator.storage.getDirectory`
+ * **absent** in WebKit and in WebKitGTK 605.1.15, the webview Tauri uses on
+ * Linux -- not slow, not quota-limited, simply not implemented. An OPFS cache
+ * would have silently never worked for Safari users or Linux desktop users.
+ * IndexedDB round-tripped a 67 MB blob on every engine tested.
+ *
+ * The cost is a structured clone on each read and write, against roughly 2 s
+ * of demosaic per frame that it avoids. `perf.bench.ts` measures the result
+ * rather than assuming it.
+ *
+ * A second consequence worth knowing: blobs and index now live in the same
+ * database, so the reconciliation in `raw-cache.ts` guards a narrower window
+ * than it was designed for. It is kept because the two are still written in
+ * separate transactions, so a crash between them remains possible.
+ */
+
+import type { BlobStore } from "./raw-cache.types";
+import { blobKeys, deleteBlob, getBlob, putBlob } from "./storage/kv";
+
+/**
+ * Whether this host can back the cache at all.
+ *
+ * Always true where the app runs -- IndexedDB is what presets, settings and
+ * run history already depend on -- but the caller reads better for asking,
+ * and a host without it degrades to converting every time rather than
+ * throwing.
+ */
+export function blobStoreAvailable(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+export function idbBlobStore(): BlobStore {
+  return {
+    keys: () => blobKeys(),
+    read: (key) => getBlob(key),
+    remove: async (key) => {
+      await deleteBlob(key);
+    },
+    write: async (key, bytes) => {
+      await putBlob(key, bytes);
+    },
+  };
+}

--- a/src/lib/raw-cache-key.test.ts
+++ b/src/lib/raw-cache-key.test.ts
@@ -79,6 +79,27 @@ describe("the RAW cache key", () => {
     expect(after).not.toBe(before);
   });
 
+  it("changes the tag when the emscripten version changes", async () => {
+    // F3: rebuilding dcraw_emu.wasm from the same LibRaw commit on a bumped
+    // Emscripten toolchain (what #244 automates) must miss rather than reuse
+    // a stale TIFF -- the commit alone can't see that kind of rebuild.
+    mockFetch(VERSIONS);
+    const before = await toolTag("https://example.test/wasm");
+
+    resetToolTagForTests();
+    mockFetch({ ...VERSIONS, emscripten: "6.0.9" });
+    const after = await toolTag("https://example.test/wasm");
+
+    expect(after).not.toBe(before);
+  });
+
+  it("throws rather than substitute a placeholder when emscripten is missing", async () => {
+    mockFetch({ ...VERSIONS, emscripten: undefined });
+    await expect(toolTag("https://example.test/wasm")).rejects.toThrow(
+      "https://example.test/wasm/versions.json is missing emscripten"
+    );
+  });
+
   it("changes the tag when dcrawArgs's flags change", async () => {
     // Guards the repair to the brief's truncated template literal: a version
     // that silently drops the args from the hash again would pass every

--- a/src/lib/raw-cache-key.test.ts
+++ b/src/lib/raw-cache-key.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { rawCacheKey, resetToolTagForTests, toolTag } from "./raw-cache-key";
+
+const VERSIONS = {
+  emscripten: "6.0.4",
+  tools: {
+    dcraw_emu: { commit: "c9d6743", describe: "", repository: "", version: "" },
+  },
+};
+
+function mockFetch(body: unknown) {
+  globalThis.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(body), ok: true })
+  ) as unknown as typeof fetch;
+}
+
+const CACHE_KEY_PATTERN = /^[0-9a-f]{64}-abc123def456$/;
+const TOOL_TAG_PATTERN = /^[0-9a-f]{12}$/;
+
+describe("the RAW cache key", () => {
+  beforeEach(() => {
+    resetToolTagForTests();
+  });
+
+  it("joins a content hash and a tool tag", async () => {
+    const key = await rawCacheKey(new Uint8Array([1, 2, 3]), "abc123def456");
+    expect(key).toMatch(CACHE_KEY_PATTERN);
+  });
+
+  it("gives different keys to different bytes", async () => {
+    expect(await rawCacheKey(new Uint8Array([1]), "t")).not.toBe(
+      await rawCacheKey(new Uint8Array([2]), "t")
+    );
+  });
+
+  it("derives a twelve-character tag from the recorded commit", async () => {
+    mockFetch(VERSIONS);
+    const tag = await toolTag("https://example.test/wasm");
+    expect(tag).toMatch(TOOL_TAG_PATTERN);
+  });
+
+  it("changes the tag when the dcraw_emu commit changes", async () => {
+    mockFetch(VERSIONS);
+    const before = await toolTag("https://example.test/wasm");
+
+    resetToolTagForTests();
+    mockFetch({
+      ...VERSIONS,
+      tools: { dcraw_emu: { ...VERSIONS.tools.dcraw_emu, commit: "deadbee" } },
+    });
+    const after = await toolTag("https://example.test/wasm");
+
+    expect(after).not.toBe(before);
+  });
+
+  it("fetches versions.json from the absolute base it is given", async () => {
+    mockFetch(VERSIONS);
+    await toolTag("https://example.test/wasm");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://example.test/wasm/versions.json"
+    );
+  });
+
+  it("asks once per base URL", async () => {
+    mockFetch(VERSIONS);
+    await toolTag("https://example.test/wasm");
+    await toolTag("https://example.test/wasm");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/raw-cache-key.test.ts
+++ b/src/lib/raw-cache-key.test.ts
@@ -1,4 +1,29 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+declare const jest: typeof import("@jest/globals").jest;
+
+const DEFAULT_ARGS = ["-T", "-o", "1", "-W", "-j", "-q", "3"];
+
+/**
+ * A double for `dcrawArgs`, so a test can vary the flags it returns without
+ * touching the real flag set. Its return value is what the tag must track --
+ * that is the whole point of folding the tool tag into the key -- so a test
+ * has to be able to change it independently of the recorded commit.
+ */
+const mockDcrawArgs = jest.fn(
+  (_inputPath: string, _outputPath: string) => DEFAULT_ARGS
+);
+
+// A thin wrapper, not `dcrawArgs: mockDcrawArgs` directly: the factory below
+// runs the moment "./pipeline/stages" is required, which -- once the mock
+// call is hoisted above imports -- is before `mockDcrawArgs` is assigned.
+// Deferring the reference into a nested closure means it is only read when
+// the mocked `dcrawArgs` is actually called, by which point it exists.
+jest.mock("./pipeline/stages", () => ({
+  dcrawArgs: (inputPath: string, outputPath: string) =>
+    mockDcrawArgs(inputPath, outputPath),
+}));
+
 import { rawCacheKey, resetToolTagForTests, toolTag } from "./raw-cache-key";
 
 const VERSIONS = {
@@ -20,6 +45,7 @@ const TOOL_TAG_PATTERN = /^[0-9a-f]{12}$/;
 describe("the RAW cache key", () => {
   beforeEach(() => {
     resetToolTagForTests();
+    mockDcrawArgs.mockReturnValue(DEFAULT_ARGS);
   });
 
   it("joins a content hash and a tool tag", async () => {
@@ -53,6 +79,21 @@ describe("the RAW cache key", () => {
     expect(after).not.toBe(before);
   });
 
+  it("changes the tag when dcrawArgs's flags change", async () => {
+    // Guards the repair to the brief's truncated template literal: a version
+    // that silently drops the args from the hash again would pass every
+    // other test here but fail this one.
+    mockFetch(VERSIONS);
+    mockDcrawArgs.mockReturnValue(["-T", "-o", "1"]);
+    const before = await toolTag("https://example.test/wasm");
+
+    resetToolTagForTests();
+    mockDcrawArgs.mockReturnValue(["-T", "-o", "2"]);
+    const after = await toolTag("https://example.test/wasm");
+
+    expect(after).not.toBe(before);
+  });
+
   it("fetches versions.json from the absolute base it is given", async () => {
     mockFetch(VERSIONS);
     await toolTag("https://example.test/wasm");
@@ -66,5 +107,33 @@ describe("the RAW cache key", () => {
     await toolTag("https://example.test/wasm");
     await toolTag("https://example.test/wasm");
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws rather than substitute a placeholder when the commit is missing", async () => {
+    // A placeholder like "unknown" would let two builds that both fail to
+    // report a commit collide on the same tag and share a cache entry --
+    // exactly the wrong-pixels hit this module exists to prevent.
+    mockFetch({
+      ...VERSIONS,
+      tools: { dcraw_emu: { ...VERSIONS.tools.dcraw_emu, commit: undefined } },
+    });
+    await expect(toolTag("https://example.test/wasm")).rejects.toThrow(
+      "https://example.test/wasm/versions.json is missing tools.dcraw_emu.commit"
+    );
+  });
+
+  it("does not remember a missing-commit failure, so a later call can still succeed", async () => {
+    mockFetch({
+      ...VERSIONS,
+      tools: { dcraw_emu: { ...VERSIONS.tools.dcraw_emu, commit: undefined } },
+    });
+    await expect(toolTag("https://example.test/wasm")).rejects.toThrow();
+
+    // No resetToolTagForTests() call here: recovery must come from the
+    // production delete-on-catch, not from the test clearing the memo map.
+    mockFetch(VERSIONS);
+    await expect(toolTag("https://example.test/wasm")).resolves.toMatch(
+      TOOL_TAG_PATTERN
+    );
   });
 });

--- a/src/lib/raw-cache-key.ts
+++ b/src/lib/raw-cache-key.ts
@@ -41,8 +41,10 @@ export function toolTag(wasmBaseUrl: string): Promise<string> {
     return cached;
   }
   const deriving = derive(wasmBaseUrl).catch((error: unknown) => {
-    // Not remembered, so a transient fetch failure does not pin an
-    // "unknown" tag for the life of the worker.
+    // Not remembered, so a transient fetch failure -- or a versions.json that
+    // is missing the commit it must report -- does not pin a failure for the
+    // life of the worker; a later call with a healthy response can still
+    // succeed.
     tags.delete(wasmBaseUrl);
     throw error;
   });
@@ -56,7 +58,19 @@ async function derive(wasmBaseUrl: string): Promise<string> {
     throw new Error(`${wasmBaseUrl}/versions.json returned ${response.status}`);
   }
   const versions = (await response.json()) as VersionsDocument;
-  const commit = versions.tools?.dcraw_emu?.commit ?? "unknown";
+  const commit = versions.tools?.dcraw_emu?.commit;
+  if (!commit) {
+    // Substituting a placeholder here would let two builds that both fail to
+    // report a commit -- the likely case, since one build-script bug affects
+    // every artifact -- collide on the same tag and share a cache entry, each
+    // serving the other's pixels. Throwing instead is safe: the caller (see
+    // raw-worker.ts, task 8) falls through to converting without a cache hit
+    // or write, so the conversion still succeeds and only the persistent
+    // cache is lost for the session.
+    throw new Error(
+      `${wasmBaseUrl}/versions.json is missing tools.dcraw_emu.commit`
+    );
+  }
   // Placeholder paths, so the tag tracks the flags and does not vary per frame.
   const args = dcrawArgs("in", "out").join(" ");
   const digest = await sha256Hex(new TextEncoder().encode(`${commit}:${args}`));

--- a/src/lib/raw-cache-key.ts
+++ b/src/lib/raw-cache-key.ts
@@ -1,0 +1,76 @@
+/**
+ * What names a cached conversion.
+ *
+ * Two parts, and the second is the one that is easy to leave out:
+ *
+ *  - **The content hash.** Not the path. `registerSessionFile` mints
+ *    `/session/<n>/<name>` from a counter that restarts each session, so the
+ *    same path names different bytes across visits and a path-keyed cache
+ *    would serve the wrong image.
+ *  - **A tool tag**, derived from the `dcraw_emu` commit the wasm was built
+ *    from and the flags it is run with. Without it, rebuilding the artifacts
+ *    (#244 automates exactly that) would serve pixels produced by a different
+ *    demosaic while reporting success -- undoing the byte-identical guarantee
+ *    `raw-preview.ts` exists to hold.
+ *
+ * Folded into the key rather than checked on read, so a tool change simply
+ * misses, stale entries age out by LRU, and a rollback re-hits its own entries
+ * instead of having discarded them.
+ */
+
+import { sha256Hex } from "./hash";
+import { dcrawArgs } from "./pipeline/stages";
+
+interface VersionsDocument {
+  tools?: Record<string, { commit?: string } | undefined>;
+}
+
+/** Memoised per base URL: the file describes committed artifacts. */
+const tags = new Map<string, Promise<string>>();
+
+/**
+ * Identity of the converter, as twelve hex characters.
+ *
+ * `build-versions.ts` is not reused here because it hardcodes a relative
+ * `/wasm`, and in a worker a relative URL resolves against the worker's own
+ * chunk rather than the document. The absolute base is passed in instead.
+ */
+export function toolTag(wasmBaseUrl: string): Promise<string> {
+  const cached = tags.get(wasmBaseUrl);
+  if (cached) {
+    return cached;
+  }
+  const deriving = derive(wasmBaseUrl).catch((error: unknown) => {
+    // Not remembered, so a transient fetch failure does not pin an
+    // "unknown" tag for the life of the worker.
+    tags.delete(wasmBaseUrl);
+    throw error;
+  });
+  tags.set(wasmBaseUrl, deriving);
+  return deriving;
+}
+
+async function derive(wasmBaseUrl: string): Promise<string> {
+  const response = await fetch(`${wasmBaseUrl}/versions.json`);
+  if (!response.ok) {
+    throw new Error(`${wasmBaseUrl}/versions.json returned ${response.status}`);
+  }
+  const versions = (await response.json()) as VersionsDocument;
+  const commit = versions.tools?.dcraw_emu?.commit ?? "unknown";
+  // Placeholder paths, so the tag tracks the flags and does not vary per frame.
+  const args = dcrawArgs("in", "out").join(" ");
+  const digest = await sha256Hex(new TextEncoder().encode(`${commit}:${args}`));
+  return digest.slice(0, 12);
+}
+
+/** `<content hash>-<tool tag>`. */
+export async function rawCacheKey(
+  bytes: Uint8Array,
+  tag: string
+): Promise<string> {
+  return `${await sha256Hex(bytes)}-${tag}`;
+}
+
+export function resetToolTagForTests(): void {
+  tags.clear();
+}

--- a/src/lib/raw-cache-key.ts
+++ b/src/lib/raw-cache-key.ts
@@ -8,10 +8,12 @@
  *    same path names different bytes across visits and a path-keyed cache
  *    would serve the wrong image.
  *  - **A tool tag**, derived from the `dcraw_emu` commit the wasm was built
- *    from and the flags it is run with. Without it, rebuilding the artifacts
- *    (#244 automates exactly that) would serve pixels produced by a different
- *    demosaic while reporting success -- undoing the byte-identical guarantee
- *    `raw-preview.ts` exists to hold.
+ *    from, the Emscripten toolchain version it was compiled with, and the
+ *    flags it is run with. All three, not just the commit: #244 automates
+ *    rebuilding from the same LibRaw commit on a bumped Emscripten, and a tag
+ *    that only hashed the commit would call that an identical build and serve
+ *    a stale TIFF as a hit over potentially different bytes -- undoing the
+ *    byte-identical guarantee `raw-preview.ts` exists to hold.
  *
  * Folded into the key rather than checked on read, so a tool change simply
  * misses, stale entries age out by LRU, and a rollback re-hits its own entries
@@ -22,6 +24,7 @@ import { sha256Hex } from "./hash";
 import { dcrawArgs } from "./pipeline/stages";
 
 interface VersionsDocument {
+  emscripten?: string;
   tools?: Record<string, { commit?: string } | undefined>;
 }
 
@@ -71,9 +74,21 @@ async function derive(wasmBaseUrl: string): Promise<string> {
       `${wasmBaseUrl}/versions.json is missing tools.dcraw_emu.commit`
     );
   }
+  const { emscripten } = versions;
+  if (!emscripten) {
+    // Same reasoning as the missing-commit guard above: a placeholder would
+    // let two builds that both fail to report it collide on one tag instead
+    // of missing safely.
+    throw new Error(`${wasmBaseUrl}/versions.json is missing emscripten`);
+  }
   // Placeholder paths, so the tag tracks the flags and does not vary per frame.
   const args = dcrawArgs("in", "out").join(" ");
-  const digest = await sha256Hex(new TextEncoder().encode(`${commit}:${args}`));
+  // Emscripten folded in alongside the commit: rebuilding dcraw_emu.wasm from
+  // the same LibRaw commit on a bumped toolchain (#244 automates this) can
+  // still change the emitted bytes, and the commit alone can't see that.
+  const digest = await sha256Hex(
+    new TextEncoder().encode(`${commit}:${emscripten}:${args}`)
+  );
   return digest.slice(0, 12);
 }
 

--- a/src/lib/raw-cache-quota.test.ts
+++ b/src/lib/raw-cache-quota.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `navigator.storage` is not implemented in jsdom, so every case here defines
+ * it on the fly with `Object.defineProperty` (existing browser globals in
+ * jsdom are read-only accessors, so a plain assignment throws) and restores
+ * it afterwards -- `undefined` in jsdom is the accurate "absent" baseline for
+ * the next test in this file, not a leftover from whichever case ran before.
+ */
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  estimateQuotaBytes,
+  persistStorageBestEffort,
+} from "./raw-cache-quota";
+
+afterEach(() => {
+  Object.defineProperty(navigator, "storage", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("estimateQuotaBytes", () => {
+  it("returns the quota navigator.storage.estimate reports", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: { estimate: () => Promise.resolve({ quota: 12_345, usage: 0 }) },
+    });
+    await expect(estimateQuotaBytes()).resolves.toBe(12_345);
+  });
+
+  it("returns undefined when navigator.storage is absent", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: undefined,
+    });
+    await expect(estimateQuotaBytes()).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when quota is not a number (WebKit's null, in CI)", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: { estimate: () => Promise.resolve({ quota: null, usage: 0 }) },
+    });
+    await expect(estimateQuotaBytes()).resolves.toBeUndefined();
+  });
+
+  it("returns undefined rather than throwing when estimate() rejects", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: { estimate: () => Promise.reject(new Error("nope")) },
+    });
+    await expect(estimateQuotaBytes()).resolves.toBeUndefined();
+  });
+});
+
+describe("persistStorageBestEffort", () => {
+  it("calls navigator.storage.persist()", async () => {
+    const persist = jest.fn(() => Promise.resolve(true));
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: { persist },
+    });
+    await persistStorageBestEffort();
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when navigator.storage.persist is absent", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: {},
+    });
+    await expect(persistStorageBestEffort()).resolves.toBeUndefined();
+  });
+
+  it("does not throw when persist() itself rejects", async () => {
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: { persist: () => Promise.reject(new Error("refused")) },
+    });
+    await expect(persistStorageBestEffort()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/raw-cache-quota.ts
+++ b/src/lib/raw-cache-quota.ts
@@ -1,0 +1,47 @@
+/**
+ * The one file that touches `navigator.storage` for the persistent RAW cache.
+ *
+ * `raw-cache.ts` stays free of it deliberately -- the same reason it never
+ * names OPFS or IndexedDB directly: `navigator.storage` does not exist under
+ * Jest, so anything that calls it lives here and is injected into the tier
+ * as a function, the same seam `BlobStore` already establishes for the blobs
+ * themselves.
+ */
+
+/**
+ * The origin's reported storage quota, in bytes, or `undefined` where the
+ * host does not say -- no `navigator.storage.estimate`, a rejected call, or a
+ * response with no numeric `quota` (recorded as `null` from WebKit in CI).
+ * Never throws: an unknown quota is what tells `raw-cache.ts` to fall back to
+ * its fixed nominal ceiling rather than a value it can't clamp against.
+ */
+export async function estimateQuotaBytes(): Promise<number | undefined> {
+  try {
+    const estimate = await navigator.storage?.estimate?.();
+    return typeof estimate?.quota === "number" ? estimate.quota : undefined;
+  } catch {
+    // Unknown, not thrown: see the doc comment above.
+  }
+}
+
+/**
+ * Asks the browser not to reclaim this origin's storage under pressure
+ * without asking first. Best-effort and silent on failure: `persist()` is not
+ * implemented everywhere `estimate()` is (it has a history of being
+ * window-only on some engines), and a host that declines it, or lacks it
+ * outright, must not stop the cache from working -- it only becomes a more
+ * evictable one.
+ *
+ * Worth calling regardless: this cache can add up to a couple of gigabytes to
+ * an origin that has never asked for persistence, which makes the whole
+ * origin -- presets and settings included, not just these blobs -- a more
+ * attractive target for the browser's storage-pressure eviction than it was
+ * before this cache existed.
+ */
+export async function persistStorageBestEffort(): Promise<void> {
+  try {
+    await navigator.storage?.persist?.();
+  } catch {
+    // Best-effort, see above.
+  }
+}

--- a/src/lib/raw-cache.test.ts
+++ b/src/lib/raw-cache.test.ts
@@ -71,11 +71,28 @@ describe("the persistent RAW cache", () => {
   });
 
   it("never evicts the entry just added", async () => {
+    // A key that is already present keeps its original position in the
+    // index, so growing it back up to the others' size and giving it a
+    // `lastUsed` tied with theirs is enough to make it the *first* candidate
+    // in eviction order -- unless the "never the just-added key" filter
+    // excludes it. Two same-sized entries can't discriminate this: a
+    // brand-new key is always appended last and so is always safe on its
+    // own, regardless of that filter. Only re-growing a key that was
+    // already there exercises the guard.
     const store = fakeStore();
-    const cache = createRawCache({ budgetBytes: 20, now: clock(), store });
-    await cache.put("a", new Uint8Array(20));
-    await cache.put("b", new Uint8Array(20));
-    expect(store.blobs.has("b")).toBe(true);
+    const times = [1000, 2000, 2000, 2000]; // a, b, c, then a again -- tied with b and c
+    const cache = createRawCache({
+      budgetBytes: 25,
+      now: () => times.shift() ?? 0,
+      store,
+    });
+
+    await cache.put("a", new Uint8Array(5));
+    await cache.put("b", new Uint8Array(10));
+    await cache.put("c", new Uint8Array(10));
+    await cache.put("a", new Uint8Array(10)); // total now 30 > 25: eviction runs
+
+    expect(store.blobs.has("a")).toBe(true);
   });
 
   it("refuses a blob larger than the whole budget", async () => {
@@ -97,5 +114,57 @@ describe("the persistent RAW cache", () => {
 
   it("defaults to a 2 GB budget", () => {
     expect(BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
+  });
+});
+
+describe("reconciliation", () => {
+  it("reports a miss and forgets the entry when the blob has vanished", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("a", new Uint8Array(10));
+
+    store.blobs.delete("a"); // as a browser reclaiming storage would
+
+    expect(await cache.get("a")).toBeUndefined();
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("deletes blobs the index does not know about", async () => {
+    const store = fakeStore();
+    store.blobs.set("orphan", new Uint8Array(10)); // a crashed write
+
+    const cache = createRawCache({ now: clock(), store });
+    await cache.sweep();
+
+    expect(store.blobs.has("orphan")).toBe(false);
+  });
+
+  it("sweeps once, not on every call", async () => {
+    const store = fakeStore();
+    let listed = 0;
+    const counting = {
+      ...store,
+      keys: () => {
+        listed += 1;
+        return store.keys();
+      },
+    };
+    const cache = createRawCache({ now: clock(), store: counting });
+
+    await cache.get("a");
+    await cache.get("b");
+    await cache.put("c", new Uint8Array(1));
+
+    expect(listed).toBe(1);
+  });
+
+  it("keeps blobs the index does know about", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("kept", new Uint8Array(10));
+
+    await cache.sweep();
+
+    expect(store.blobs.has("kept")).toBe(true);
   });
 });

--- a/src/lib/raw-cache.test.ts
+++ b/src/lib/raw-cache.test.ts
@@ -28,6 +28,8 @@ function fakeStore(): BlobStore & { blobs: Map<string, Uint8Array> } {
   };
 }
 
+const ONE_FAILED_ENTRY = /1/;
+
 /** A distinct clock, so "least recently used" is decided rather than raced. */
 function clock() {
   let time = 1000;
@@ -110,6 +112,48 @@ describe("the persistent RAW cache", () => {
     await cache.clear();
     expect(store.blobs.size).toBe(0);
     expect(await cache.usage()).toBe(0);
+  });
+
+  it("keeps an entry in the index when its blob cannot be removed, and rejects", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("keeps", new Uint8Array(10));
+    await cache.put("goes", new Uint8Array(15));
+
+    // Only "keeps" fails to remove, so a naive implementation that keeps
+    // everything (rather than exactly the failed entry) would still pass a
+    // test that merely checks usage() is nonzero.
+    const flaky: BlobStore = {
+      ...store,
+      remove: (key) =>
+        key === "keeps"
+          ? Promise.reject(new Error("locked"))
+          : store.remove(key),
+    };
+    const flakyCache = createRawCache({ now: clock(), store: flaky });
+
+    await expect(flakyCache.clear()).rejects.toThrow();
+    expect(store.blobs.has("keeps")).toBe(true);
+    expect(store.blobs.has("goes")).toBe(false);
+    expect(await flakyCache.usage()).toBe(10);
+  });
+
+  it("names how many entries could not be removed", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("keeps", new Uint8Array(10));
+    await cache.put("goes", new Uint8Array(15));
+
+    const flaky: BlobStore = {
+      ...store,
+      remove: (key) =>
+        key === "keeps"
+          ? Promise.reject(new Error("locked"))
+          : store.remove(key),
+    };
+    const flakyCache = createRawCache({ now: clock(), store: flaky });
+
+    await expect(flakyCache.clear()).rejects.toThrow(ONE_FAILED_ENTRY);
   });
 
   it("defaults to a 2 GB budget", () => {

--- a/src/lib/raw-cache.test.ts
+++ b/src/lib/raw-cache.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "@jest/globals";
-import { BUDGET_BYTES, createRawCache } from "./raw-cache";
+import { BUDGET_BYTES, createRawCache, QUOTA_SHARE } from "./raw-cache";
 import type { BlobStore } from "./raw-cache.types";
 import { deleteDocument } from "./storage/kv";
 
@@ -22,6 +22,37 @@ function fakeStore(): BlobStore & { blobs: Map<string, Uint8Array> } {
       return Promise.resolve();
     },
     write: (key, bytes) => {
+      blobs.set(key, bytes);
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * A store whose `write` fails the first `failures` times it's called for a
+ * given key, then succeeds. Models the F2 wedge: a real quota smaller than
+ * the nominal 2 GB ceiling, where `store.write` is what actually fails, not
+ * the index accounting.
+ */
+function flakyStore(
+  failures: Record<string, number> = {}
+): BlobStore & { blobs: Map<string, Uint8Array> } {
+  const blobs = new Map<string, Uint8Array>();
+  const remaining = { ...failures };
+  return {
+    blobs,
+    keys: () => Promise.resolve(Array.from(blobs.keys())),
+    read: (key) => Promise.resolve(blobs.get(key)),
+    remove: (key) => {
+      blobs.delete(key);
+      return Promise.resolve();
+    },
+    write: (key, bytes) => {
+      const left = remaining[key] ?? 0;
+      if (left > 0) {
+        remaining[key] = left - 1;
+        return Promise.reject(new Error("quota exceeded"));
+      }
       blobs.set(key, bytes);
       return Promise.resolve();
     },
@@ -158,6 +189,109 @@ describe("the persistent RAW cache", () => {
 
   it("defaults to a 2 GB budget", () => {
     expect(BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
+  });
+});
+
+describe("the effective budget", () => {
+  it("uses the nominal ceiling when no quota is reported", async () => {
+    const cache = createRawCache({
+      estimateQuota: () => Promise.resolve(undefined),
+      now: clock(),
+      store: fakeStore(),
+    });
+    expect(await cache.budget()).toBe(BUDGET_BYTES);
+  });
+
+  it("clamps to a share of a smaller reported quota", async () => {
+    const quota = 1000;
+    const cache = createRawCache({
+      estimateQuota: () => Promise.resolve(quota),
+      now: clock(),
+      store: fakeStore(),
+    });
+    expect(await cache.budget()).toBe(Math.floor(quota * QUOTA_SHARE));
+  });
+
+  it("never clamps above the nominal ceiling on a huge quota", async () => {
+    const cache = createRawCache({
+      estimateQuota: () => Promise.resolve(BUDGET_BYTES * 10),
+      now: clock(),
+      store: fakeStore(),
+    });
+    expect(await cache.budget()).toBe(BUDGET_BYTES);
+  });
+
+  it("ignores a reported quota when budgetBytes is set explicitly", async () => {
+    // The override every other test in this file relies on: it must win
+    // outright, not be clamped a second time against a quota a test never
+    // intends to model.
+    const cache = createRawCache({
+      budgetBytes: 30,
+      estimateQuota: () => Promise.resolve(5),
+      now: clock(),
+      store: fakeStore(),
+    });
+    expect(await cache.budget()).toBe(30);
+  });
+
+  it("shrinks eviction to match a quota-clamped budget", async () => {
+    // The actual bug F2 fixes: a fixed nominal budget lets an over-quota
+    // index look comfortably under budget and never evict. Small quota (100)
+    // clamps the effective budget to 50; two 30-byte entries (60 total)
+    // exceed that, so the older one must go, even though 60 is nowhere near
+    // the nominal BUDGET_BYTES.
+    const store = fakeStore();
+    const cache = createRawCache({
+      estimateQuota: () => Promise.resolve(100),
+      now: clock(),
+      store,
+    });
+    await cache.put("old", new Uint8Array(30));
+    await cache.put("new", new Uint8Array(30));
+
+    expect(store.blobs.has("old")).toBe(false);
+    expect(store.blobs.has("new")).toBe(true);
+  });
+});
+
+describe("recovering from a write failure", () => {
+  it("evicts and retries once, rather than losing the conversion", async () => {
+    const store = flakyStore({ new: 1 });
+    const cache = createRawCache({ budgetBytes: 20, now: clock(), store });
+
+    await cache.put("old", new Uint8Array(15));
+    await cache.put("new", new Uint8Array(15)); // first write() rejects
+
+    expect(Array.from((await cache.get("new")) ?? [])).toEqual(
+      Array.from(new Uint8Array(15))
+    );
+  });
+
+  it("frees room even when the index looks comfortably under budget", async () => {
+    // Discriminates the failure-path eviction from the normal budget-gated
+    // one: with budgetBytes generous (1000), "old" (15) + "new" (15) never
+    // approaches budget, so an implementation that only evicts when *over
+    // budget* would free nothing here and the retry would hit the identical
+    // failure. Freeing space unconditionally on a write failure -- what F2
+    // requires -- evicts "old" anyway, because the failure itself is the
+    // evidence the budget figure doesn't match what the store can hold.
+    const store = flakyStore({ new: 1 });
+    const cache = createRawCache({ budgetBytes: 1000, now: clock(), store });
+
+    await cache.put("old", new Uint8Array(15));
+    await cache.put("new", new Uint8Array(15));
+
+    expect(store.blobs.has("old")).toBe(false);
+    expect(Array.from((await cache.get("new")) ?? [])).toEqual(
+      Array.from(new Uint8Array(15))
+    );
+  });
+
+  it("propagates a write failure that eviction and one retry could not fix", async () => {
+    const store = flakyStore({ stuck: Number.POSITIVE_INFINITY });
+    const cache = createRawCache({ budgetBytes: 1000, now: clock(), store });
+
+    await expect(cache.put("stuck", new Uint8Array(10))).rejects.toThrow();
   });
 });
 

--- a/src/lib/raw-cache.test.ts
+++ b/src/lib/raw-cache.test.ts
@@ -1,0 +1,101 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { BUDGET_BYTES, createRawCache } from "./raw-cache";
+import type { BlobStore } from "./raw-cache.types";
+import { deleteDocument } from "./storage/kv";
+
+// One document holds the whole index, and fake-indexeddb outlives an `it`
+// block, so without this each test inherits the previous test's entries --
+// against a fresh store that has none of their blobs.
+beforeEach(async () => {
+  await deleteDocument("raw-cache-index");
+});
+
+function fakeStore(): BlobStore & { blobs: Map<string, Uint8Array> } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    blobs,
+    keys: () => Promise.resolve(Array.from(blobs.keys())),
+    read: (key) => Promise.resolve(blobs.get(key)),
+    remove: (key) => {
+      blobs.delete(key);
+      return Promise.resolve();
+    },
+    write: (key, bytes) => {
+      blobs.set(key, bytes);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A distinct clock, so "least recently used" is decided rather than raced. */
+function clock() {
+  let time = 1000;
+  return () => {
+    time += 1000;
+    return time;
+  };
+}
+
+describe("the persistent RAW cache", () => {
+  it("returns undefined for a key it has never seen", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    expect(await cache.get("absent")).toBeUndefined();
+  });
+
+  it("returns what was put", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    await cache.put("a", new Uint8Array([1, 2, 3]));
+    expect(Array.from((await cache.get("a")) ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("reports usage as the sum of stored sizes", async () => {
+    const cache = createRawCache({ now: clock(), store: fakeStore() });
+    await cache.put("a", new Uint8Array(10));
+    await cache.put("b", new Uint8Array(15));
+    expect(await cache.usage()).toBe(25);
+  });
+
+  it("evicts least recently used first when over budget", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 30, now: clock(), store });
+
+    await cache.put("old", new Uint8Array(10));
+    await cache.put("mid", new Uint8Array(10));
+    await cache.get("old"); // touches "old", making "mid" the oldest use
+    await cache.put("new", new Uint8Array(15));
+
+    expect(store.blobs.has("mid")).toBe(false);
+    expect(store.blobs.has("old")).toBe(true);
+    expect(store.blobs.has("new")).toBe(true);
+  });
+
+  it("never evicts the entry just added", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 20, now: clock(), store });
+    await cache.put("a", new Uint8Array(20));
+    await cache.put("b", new Uint8Array(20));
+    expect(store.blobs.has("b")).toBe(true);
+  });
+
+  it("refuses a blob larger than the whole budget", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ budgetBytes: 10, now: clock(), store });
+    await cache.put("huge", new Uint8Array(11));
+    expect(store.blobs.has("huge")).toBe(false);
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("clears every blob and resets usage", async () => {
+    const store = fakeStore();
+    const cache = createRawCache({ now: clock(), store });
+    await cache.put("a", new Uint8Array(10));
+    await cache.clear();
+    expect(store.blobs.size).toBe(0);
+    expect(await cache.usage()).toBe(0);
+  });
+
+  it("defaults to a 2 GB budget", () => {
+    expect(BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
+  });
+});

--- a/src/lib/raw-cache.ts
+++ b/src/lib/raw-cache.ts
@@ -8,9 +8,11 @@
  * counter that restarts each session and therefore names different bytes with
  * the same string across visits.
  *
- * Storage is injected. OPFS is the intended backing (`raw-cache-opfs.ts`), but
- * this module never names it: the eviction and index logic is the part worth
- * testing, and `navigator.storage` does not exist under Jest.
+ * Storage is injected. IndexedDB is the actual backing (`raw-cache-idb.ts`),
+ * and `navigator.storage` -- used to clamp the budget and to ask for
+ * persistence -- is injected the same way, in `raw-cache-quota.ts`: this
+ * module never names either, so the eviction and index logic is the part
+ * worth testing, and stays testable under Jest, where neither exists.
  *
  * The index is a single document rather than a row per entry. At a 2 GB budget
  * and ~67 MB per converted frame that is about thirty entries, so one document
@@ -23,17 +25,41 @@ import { getDocument, updateDocument } from "./storage/kv";
 
 const INDEX_KEY = "raw-cache-index";
 
-/** See the design doc. Fixed rather than a share of the origin quota. */
+/**
+ * The nominal ceiling. Not the effective one any more: `budget()` below
+ * clamps this against the origin's real quota where that's known, because a
+ * fixed 2 GiB figure on a host whose actual quota is smaller means the
+ * eviction loop in `put()` never runs -- the index never looks full even
+ * though the disk already is.
+ */
 export const BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
+
+/**
+ * How much of the origin's reported quota this cache may claim. Well under 1:
+ * the same origin also holds presets, settings and run history (small, but
+ * not optional), and a cache that budgeted the *whole* quota would start
+ * evicting only once nothing was left for anything else sharing it.
+ */
+export const QUOTA_SHARE = 0.5;
 
 export interface RawCacheOptions {
   budgetBytes?: number;
+  /**
+   * Reports the origin's storage quota in bytes, or `undefined` where it
+   * isn't known. Omit to skip clamping entirely and use `BUDGET_BYTES`
+   * outright -- what every existing caller of this module did before F2, and
+   * still what a host with no quota API gets. `estimateQuotaBytes` in
+   * `raw-cache-quota.ts` is the production implementation.
+   */
+  estimateQuota?: () => Promise<number | undefined>;
   /** Injected so eviction order is decided in tests rather than raced. */
   now?: () => number;
   store: BlobStore;
 }
 
 export interface RawCache {
+  /** The effective ceiling this instance will evict down to. See `budget()`. */
+  budget: () => Promise<number>;
   clear: () => Promise<void>;
   get: (key: string) => Promise<Uint8Array | undefined>;
   put: (key: string, bytes: Uint8Array) => Promise<void>;
@@ -44,8 +70,26 @@ export interface RawCache {
 
 export function createRawCache(options: RawCacheOptions): RawCache {
   const { store } = options;
-  const budget = options.budgetBytes ?? BUDGET_BYTES;
   const now = options.now ?? (() => Date.now());
+
+  // Resolved once per instance and memoised: the quota is not expected to
+  // change mid-session, and an explicit `budgetBytes` override -- what every
+  // test in this file passes -- must win outright rather than being clamped
+  // further, so it never calls `estimateQuota` at all.
+  let budgetOnce: Promise<number> | undefined;
+  function budget(): Promise<number> {
+    if (options.budgetBytes !== undefined) {
+      return Promise.resolve(options.budgetBytes);
+    }
+    budgetOnce ??= Promise.resolve(options.estimateQuota?.())
+      .catch(() => undefined)
+      .then((quota) =>
+        quota && quota > 0
+          ? Math.min(BUDGET_BYTES, Math.floor(quota * QUOTA_SHARE))
+          : BUDGET_BYTES
+      );
+    return budgetOnce;
+  }
 
   async function readIndex(): Promise<CacheIndex> {
     return (await getDocument<CacheIndex>(INDEX_KEY)) ?? {};
@@ -104,19 +148,69 @@ export function createRawCache(options: RawCacheOptions): RawCache {
     return bytes;
   }
 
+  /**
+   * Frees the LRU entries needed to make room for `neededBytes` more, judged
+   * against what is actually indexed rather than against any budget.
+   *
+   * Deliberately unconditional on `budget`: this exists for the moment a
+   * write already failed, which means the budget model was wrong for this
+   * host (an index well under a quota-clamped ceiling, on a store that is
+   * still full -- exactly what a fixed 2 GB figure produces on a smaller real
+   * quota). Gating this eviction on the same budget that just failed to
+   * predict the failure would evict nothing whenever the index looks
+   * comfortably under it, and the retry below would repeat the identical
+   * failure. Freeing roughly what is about to be written, independent of
+   * budget, is what turns that into "slower" instead of "wedged forever."
+   */
+  async function evictToMakeRoom(neededBytes: number): Promise<void> {
+    const evicted: string[] = [];
+    await updateIndex((current) => {
+      let freed = 0;
+      const order = Object.entries(current).sort(
+        ([, a], [, b]) => a.lastUsed - b.lastUsed
+      );
+      for (const [candidate, entry] of order) {
+        if (freed >= neededBytes) {
+          break;
+        }
+        delete current[candidate];
+        freed += entry.size;
+        evicted.push(candidate);
+      }
+      return current;
+    });
+    await Promise.all(
+      evicted.map((candidate) => store.remove(candidate).catch(() => undefined))
+    );
+  }
+
   async function put(key: string, bytes: Uint8Array): Promise<void> {
     await sweepOnce();
+    const effectiveBudget = await budget();
 
     // A blob bigger than the whole budget would evict everything and then
     // itself, so it is never stored at all.
-    if (bytes.byteLength > budget) {
+    if (bytes.byteLength > effectiveBudget) {
       return;
     }
 
     // Blob first, index second. An interrupted write then leaves an orphan,
     // which `sweep` reclaims, rather than a phantom the next reader must
     // discover.
-    await store.write(key, bytes);
+    try {
+      await store.write(key, bytes);
+    } catch {
+      // F2: a write failure used to be swallowed here by the caller
+      // (`convertWithCache` in raw-worker.ts) with no attempt to make room
+      // first -- correct when the budget model was trustworthy, wrong once a
+      // fixed 2 GB ceiling could sit above the host's real quota. One retry,
+      // after freeing space the index actually thinks it can spare: if the
+      // store is still full after that, something other than "the cache
+      // needs to evict" is wrong, and this is left to propagate to that same
+      // swallow rather than retried again.
+      await evictToMakeRoom(bytes.byteLength);
+      await store.write(key, bytes);
+    }
 
     const evicted: string[] = [];
     await updateIndex((current) => {
@@ -129,7 +223,7 @@ export function createRawCache(options: RawCacheOptions): RawCache {
         .filter(([candidate]) => candidate !== key)
         .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
       for (const [candidate, entry] of order) {
-        if (total <= budget) {
+        if (total <= effectiveBudget) {
           break;
         }
         delete current[candidate];
@@ -180,7 +274,7 @@ export function createRawCache(options: RawCacheOptions): RawCache {
     }
   }
 
-  return { clear, get, put, sweep, usage };
+  return { budget, clear, get, put, sweep, usage };
 }
 
 function updateIndex(

--- a/src/lib/raw-cache.ts
+++ b/src/lib/raw-cache.ts
@@ -153,10 +153,31 @@ export function createRawCache(options: RawCacheOptions): RawCache {
 
   async function clear(): Promise<void> {
     const present = await store.keys().catch(() => [] as string[]);
-    await Promise.all(
-      present.map((key) => store.remove(key).catch(() => undefined))
+    const results = await Promise.allSettled(
+      present.map((key) => store.remove(key))
     );
-    await updateIndex(() => ({}));
+    const failed = present.filter((_, i) => results[i]?.status === "rejected");
+
+    // Keep exactly the entries whose blobs survived removal. Emptying the
+    // index unconditionally is how a partial failure used to turn into a
+    // false "cleared": usage() would read 0 while the un-removed blobs sat
+    // on disk, and the settings page would report success over both.
+    const failedKeys = new Set(failed);
+    await updateIndex((current) => {
+      const next: CacheIndex = {};
+      for (const key of Object.keys(current)) {
+        const entry = current[key];
+        if (entry && failedKeys.has(key)) {
+          next[key] = entry;
+        }
+      }
+      return next;
+    });
+
+    if (failed.length > 0) {
+      const noun = failed.length === 1 ? "entry" : "entries";
+      throw new Error(`Could not clear ${failed.length} cache ${noun}`);
+    }
   }
 
   return { clear, get, put, sweep, usage };

--- a/src/lib/raw-cache.ts
+++ b/src/lib/raw-cache.ts
@@ -1,0 +1,144 @@
+/**
+ * The persistent tier of the RAW-to-TIFF cache.
+ *
+ * Sits behind the session tier in `raw-preview.ts` and in front of conversion.
+ * Content-addressed, so a file that moved is still a hit and a file that
+ * changed is not -- which is a correctness requirement rather than a nicety in
+ * the browser, where `registerSessionFile` mints `/session/<n>/<name>` from a
+ * counter that restarts each session and therefore names different bytes with
+ * the same string across visits.
+ *
+ * Storage is injected. OPFS is the intended backing (`raw-cache-opfs.ts`), but
+ * this module never names it: the eviction and index logic is the part worth
+ * testing, and `navigator.storage` does not exist under Jest.
+ *
+ * The index is a single document rather than a row per entry. At a 2 GB budget
+ * and ~67 MB per converted frame that is about thirty entries, so one document
+ * is small, updates atomically, and can be read straight from the page for the
+ * settings read-out without involving the worker.
+ */
+
+import type { BlobStore, CacheIndex } from "./raw-cache.types";
+import { getDocument, updateDocument } from "./storage/kv";
+
+const INDEX_KEY = "raw-cache-index";
+
+/** See the design doc. Fixed rather than a share of the origin quota. */
+export const BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
+
+export interface RawCacheOptions {
+  budgetBytes?: number;
+  /** Injected so eviction order is decided in tests rather than raced. */
+  now?: () => number;
+  store: BlobStore;
+}
+
+export interface RawCache {
+  clear: () => Promise<void>;
+  get: (key: string) => Promise<Uint8Array | undefined>;
+  put: (key: string, bytes: Uint8Array) => Promise<void>;
+  usage: () => Promise<number>;
+}
+
+export function createRawCache(options: RawCacheOptions): RawCache {
+  const { store } = options;
+  const budget = options.budgetBytes ?? BUDGET_BYTES;
+  const now = options.now ?? (() => Date.now());
+
+  async function readIndex(): Promise<CacheIndex> {
+    return (await getDocument<CacheIndex>(INDEX_KEY)) ?? {};
+  }
+
+  async function get(key: string): Promise<Uint8Array | undefined> {
+    const index = await readIndex();
+    if (!index[key]) {
+      return;
+    }
+
+    const bytes = await store.read(key).catch(() => undefined);
+    if (!bytes) {
+      // Phantom: the index remembers a blob the store no longer has, which is
+      // what a browser reclaiming storage under quota pressure leaves behind.
+      // Dropping the entry turns it into an ordinary miss.
+      await updateIndex((current) => {
+        delete current[key];
+        return current;
+      });
+      return;
+    }
+
+    await updateIndex((current) => {
+      const entry = current[key];
+      if (entry) {
+        entry.lastUsed = now();
+      }
+      return current;
+    });
+    return bytes;
+  }
+
+  async function put(key: string, bytes: Uint8Array): Promise<void> {
+    // A blob bigger than the whole budget would evict everything and then
+    // itself, so it is never stored at all.
+    if (bytes.byteLength > budget) {
+      return;
+    }
+
+    // Blob first, index second. An interrupted write then leaves an orphan,
+    // which `sweep` reclaims, rather than a phantom the next reader must
+    // discover.
+    await store.write(key, bytes);
+
+    const evicted: string[] = [];
+    await updateIndex((current) => {
+      current[key] = { lastUsed: now(), size: bytes.byteLength };
+      let total = Object.values(current).reduce(
+        (sum, entry) => sum + entry.size,
+        0
+      );
+      const order = Object.entries(current)
+        .filter(([candidate]) => candidate !== key)
+        .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
+      for (const [candidate, entry] of order) {
+        if (total <= budget) {
+          break;
+        }
+        delete current[candidate];
+        total -= entry.size;
+        evicted.push(candidate);
+      }
+      return current;
+    });
+
+    // Outside the index update: a failed removal must not roll back an index
+    // that is already correct. What it leaves is an orphan, which sweeps.
+    await Promise.all(
+      evicted.map((candidate) => store.remove(candidate).catch(() => undefined))
+    );
+  }
+
+  async function usage(): Promise<number> {
+    const index = await readIndex();
+    return Object.values(index).reduce((sum, entry) => sum + entry.size, 0);
+  }
+
+  async function clear(): Promise<void> {
+    const present = await store.keys().catch(() => [] as string[]);
+    await Promise.all(
+      present.map((key) => store.remove(key).catch(() => undefined))
+    );
+    await updateIndex(() => ({}));
+  }
+
+  return { clear, get, put, usage };
+}
+
+function updateIndex(
+  change: (current: CacheIndex) => CacheIndex
+): Promise<CacheIndex> {
+  return updateDocument<CacheIndex>(INDEX_KEY, (current) =>
+    change(current ?? {})
+  );
+}
+
+export type { BlobStore, CacheEntry, CacheIndex } from "./raw-cache.types";

--- a/src/lib/raw-cache.ts
+++ b/src/lib/raw-cache.ts
@@ -37,6 +37,8 @@ export interface RawCache {
   clear: () => Promise<void>;
   get: (key: string) => Promise<Uint8Array | undefined>;
   put: (key: string, bytes: Uint8Array) => Promise<void>;
+  /** Deletes blobs the index does not know about. Runs once per instance. */
+  sweep: () => Promise<void>;
   usage: () => Promise<number>;
 }
 
@@ -49,7 +51,32 @@ export function createRawCache(options: RawCacheOptions): RawCache {
     return (await getDocument<CacheIndex>(INDEX_KEY)) ?? {};
   }
 
+  /**
+   * Blobs with no index entry, deleted.
+   *
+   * A write that landed but whose index update did not is invisible to
+   * eviction, so it would consume disk for the life of the origin. About
+   * thirty keys at this budget, so listing them is cheap.
+   */
+  async function sweep(): Promise<void> {
+    const index = await readIndex();
+    const present = await store.keys().catch(() => [] as string[]);
+    await Promise.all(
+      present
+        .filter((key) => !index[key])
+        .map((key) => store.remove(key).catch(() => undefined))
+    );
+  }
+
+  /** Once per instance: a sweep on every lookup would list the store per frame. */
+  let swept: Promise<void> | undefined;
+  function sweepOnce(): Promise<void> {
+    swept ??= sweep().catch(() => undefined);
+    return swept;
+  }
+
   async function get(key: string): Promise<Uint8Array | undefined> {
+    await sweepOnce();
     const index = await readIndex();
     if (!index[key]) {
       return;
@@ -78,6 +105,8 @@ export function createRawCache(options: RawCacheOptions): RawCache {
   }
 
   async function put(key: string, bytes: Uint8Array): Promise<void> {
+    await sweepOnce();
+
     // A blob bigger than the whole budget would evict everything and then
     // itself, so it is never stored at all.
     if (bytes.byteLength > budget) {
@@ -130,7 +159,7 @@ export function createRawCache(options: RawCacheOptions): RawCache {
     await updateIndex(() => ({}));
   }
 
-  return { clear, get, put, usage };
+  return { clear, get, put, sweep, usage };
 }
 
 function updateIndex(

--- a/src/lib/raw-cache.types.ts
+++ b/src/lib/raw-cache.types.ts
@@ -1,0 +1,25 @@
+/**
+ * The persistent RAW cache's storage seam.
+ *
+ * In its own module so `raw-worker.ts` and the settings page can name these
+ * types without importing an implementation -- and so the OPFS implementation
+ * is never pulled into a Jest run, where `navigator.storage` does not exist.
+ */
+
+/** Somewhere large binary blobs live, addressed by key. */
+export interface BlobStore {
+  /** Every key present. Reconciliation only; not a hot path. */
+  keys: () => Promise<string[]>;
+  read: (key: string) => Promise<Uint8Array | undefined>;
+  remove: (key: string) => Promise<void>;
+  write: (key: string, bytes: Uint8Array) => Promise<void>;
+}
+
+export interface CacheEntry {
+  /** Epoch milliseconds. Eviction is least-recently-*used*, not oldest. */
+  lastUsed: number;
+  size: number;
+}
+
+/** key -> entry. About 30 entries at a 2 GB budget, so one document holds it. */
+export type CacheIndex = Record<string, CacheEntry>;

--- a/src/lib/raw-worker.test.ts
+++ b/src/lib/raw-worker.test.ts
@@ -6,6 +6,7 @@ function fakeCache(seed: Record<string, Uint8Array> = {}) {
   const blobs = new Map(Object.entries(seed));
   const cache: RawCache & { blobs: Map<string, Uint8Array> } = {
     blobs,
+    budget: () => Promise.resolve(0),
     clear: () => Promise.resolve(),
     get: (key) => Promise.resolve(blobs.get(key)),
     put: (key, bytes) => {

--- a/src/lib/raw-worker.test.ts
+++ b/src/lib/raw-worker.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "@jest/globals";
+import type { RawCache } from "./raw-cache";
+import { convertWithCache } from "./raw-worker";
+
+function fakeCache(seed: Record<string, Uint8Array> = {}) {
+  const blobs = new Map(Object.entries(seed));
+  const cache: RawCache & { blobs: Map<string, Uint8Array> } = {
+    blobs,
+    clear: () => Promise.resolve(),
+    get: (key) => Promise.resolve(blobs.get(key)),
+    put: (key, bytes) => {
+      blobs.set(key, bytes);
+      return Promise.resolve();
+    },
+    sweep: () => Promise.resolve(),
+    usage: () => Promise.resolve(0),
+  };
+  return cache;
+}
+
+describe("converting with the persistent cache", () => {
+  it("returns the cached TIFF without converting", async () => {
+    const cache = fakeCache({ "key-1": new Uint8Array([9, 9]) });
+    let converted = 0;
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => {
+        converted += 1;
+        return Promise.resolve(new Uint8Array([1]));
+      },
+      key: () => Promise.resolve("key-1"),
+    });
+
+    expect(Array.from(tiff)).toEqual([9, 9]);
+    expect(converted).toBe(0);
+  });
+
+  it("converts and stores on a miss", async () => {
+    const cache = fakeCache();
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([4, 5])),
+      key: () => Promise.resolve("key-2"),
+    });
+
+    expect(Array.from(tiff)).toEqual([4, 5]);
+    expect(Array.from(cache.blobs.get("key-2") ?? [])).toEqual([4, 5]);
+  });
+
+  it("still converts when the key cannot be derived", async () => {
+    const cache = fakeCache();
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([7])),
+      key: () => Promise.reject(new Error("versions.json unreachable")),
+    });
+    expect(Array.from(tiff)).toEqual([7]);
+  });
+
+  it("still returns the TIFF when the cache write fails", async () => {
+    const cache = fakeCache();
+    cache.put = () => Promise.reject(new Error("quota exceeded"));
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([8])),
+      key: () => Promise.resolve("key-3"),
+    });
+    expect(Array.from(tiff)).toEqual([8]);
+  });
+
+  it("still returns the TIFF when the cache read fails", async () => {
+    const cache = fakeCache();
+    cache.get = () => Promise.reject(new Error("storage unavailable"));
+
+    const tiff = await convertWithCache({
+      cache,
+      convert: () => Promise.resolve(new Uint8Array([6])),
+      key: () => Promise.resolve("key-4"),
+    });
+    expect(Array.from(tiff)).toEqual([6]);
+  });
+});

--- a/src/lib/raw-worker.ts
+++ b/src/lib/raw-worker.ts
@@ -23,6 +23,10 @@ import {
 import { createRawCache, type RawCache } from "./raw-cache";
 import { blobStoreAvailable, idbBlobStore } from "./raw-cache-idb";
 import { rawCacheKey, toolTag } from "./raw-cache-key";
+import {
+  estimateQuotaBytes,
+  persistStorageBestEffort,
+} from "./raw-cache-quota";
 import { convertRaw } from "./raw-convert";
 import type { RawConvertRequest, RawWorkerMessage } from "./raw-worker.types";
 
@@ -57,7 +61,19 @@ function cacheFor(): RawCache | undefined {
   if (!blobStoreAvailable()) {
     return;
   }
-  cache ??= createRawCache({ store: idbBlobStore() });
+  if (!cache) {
+    cache = createRawCache({
+      estimateQuota: estimateQuotaBytes,
+      store: idbBlobStore(),
+    });
+    // Fire-and-forget, once per worker lifetime: `persistStorageBestEffort`
+    // never rejects, and blocking the first conversion on it would trade a
+    // best-effort storage hint for the responsiveness this worker exists to
+    // protect. `app/init.tsx` also calls it from the page, since
+    // `persist()` -- unlike `estimate()` -- has a history of being
+    // unavailable from a worker on some engines.
+    persistStorageBestEffort();
+  }
   return cache;
 }
 

--- a/src/lib/raw-worker.ts
+++ b/src/lib/raw-worker.ts
@@ -20,6 +20,9 @@ import {
   urlModuleLoader,
   WasmToolRunner,
 } from "./pipeline/wasm-runner";
+import { createRawCache, type RawCache } from "./raw-cache";
+import { blobStoreAvailable, idbBlobStore } from "./raw-cache-idb";
+import { rawCacheKey, toolTag } from "./raw-cache-key";
 import { convertRaw } from "./raw-convert";
 import type { RawConvertRequest, RawWorkerMessage } from "./raw-worker.types";
 
@@ -40,6 +43,69 @@ function runnerFor(wasmBaseUrl: string): WasmToolRunner {
     load: urlModuleLoader(wasmBaseUrl),
   });
   return runner;
+}
+
+let cache: RawCache | undefined;
+
+/**
+ * The persistent tier, or nothing on a host without IndexedDB.
+ *
+ * Absence is not an error: the conversion path is unchanged and only slower,
+ * which is exactly what every host did before this existed.
+ */
+function cacheFor(): RawCache | undefined {
+  if (!blobStoreAvailable()) {
+    return;
+  }
+  cache ??= createRawCache({ store: idbBlobStore() });
+  return cache;
+}
+
+export interface CachedConversion {
+  cache: RawCache | undefined;
+  convert: () => Promise<Uint8Array>;
+  key: () => Promise<string>;
+}
+
+/**
+ * A conversion, answered from the cache where possible.
+ *
+ * Exported for tests: the worker's own message plumbing needs a real `Worker`,
+ * whereas this is the part with the decisions in it.
+ *
+ * Every cache failure falls through to conversion. The cache may never be the
+ * reason a frame fails to convert -- a read error is a miss, and a write error
+ * is a slower next session rather than a lost image.
+ */
+export async function convertWithCache({
+  cache: tier,
+  convert: performConvert,
+  key,
+}: CachedConversion): Promise<Uint8Array> {
+  let resolved: string | undefined;
+  if (tier) {
+    try {
+      resolved = await key();
+      const hit = await tier.get(resolved);
+      if (hit) {
+        return hit;
+      }
+    } catch {
+      // Unusable cache: convert, exactly as a host without one does.
+      resolved = undefined;
+    }
+  }
+
+  const tiff = await performConvert();
+
+  if (tier && resolved) {
+    // Before the caller transfers it. `postMessage` with a transfer detaches
+    // the buffer, and writing afterwards would persist a zero-byte file that
+    // later reads as a corrupt hit -- the failure fixed in 93ba5fc.
+    await tier.put(resolved, tiff).catch(() => undefined);
+  }
+
+  return tiff;
 }
 
 function post(message: RawWorkerMessage, transfer: Transferable[] = []) {
@@ -64,7 +130,12 @@ self.addEventListener("message", (event: MessageEvent<RawConvertRequest>) => {
 async function convert(request: RawConvertRequest): Promise<Uint8Array> {
   const active = runnerFor(request.wasmBaseUrl);
   try {
-    return await convertRaw(active, request.path, request.bytes);
+    return await convertWithCache({
+      cache: cacheFor(),
+      convert: () => convertRaw(active, request.path, request.bytes),
+      key: async () =>
+        rawCacheKey(request.bytes, await toolTag(request.wasmBaseUrl)),
+    });
   } finally {
     // Between frames rather than at the end: the runner survives to keep its
     // compiled modules, so its staged bytes must not survive with it.

--- a/src/lib/storage/kv-connection-retry.test.ts
+++ b/src/lib/storage/kv-connection-retry.test.ts
@@ -16,6 +16,12 @@ describe("recovering from a failed open()", () => {
     // kv.ts cached that rejected promise, every subsequent call in the
     // session -- getDocument, putDocument, presets, settings -- would reject
     // forever with this same error, not just the call that hit it.
+    // A plain object standing in for IDBOpenDBRequest, exercising only the
+    // `on*` property-assignment style kv.ts currently uses. Real
+    // IDBOpenDBRequest is an EventTarget and also supports
+    // addEventListener/dispatchEvent; if kv.ts ever moved to that API this
+    // mock would stop reflecting reality without failing loudly -- it would
+    // just silently stop exercising the failure path this test is for.
     const openSpy = jest.spyOn(indexedDB, "open").mockImplementationOnce(() => {
       const request = {
         error: new Error("simulated open failure"),

--- a/src/lib/storage/kv-connection-retry.test.ts
+++ b/src/lib/storage/kv-connection-retry.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Recovery from a failed open(), in its own file for the same reason as
+ * `kv-upgrade.test.ts`: each Jest test file gets its own module registry, so
+ * a fresh `fake-indexeddb` in-memory database and a fresh `connection`
+ * module variable, with nothing else in this run able to interfere with the
+ * failure this test injects.
+ */
+import "fake-indexeddb/auto";
+import { describe, expect, it, jest } from "@jest/globals";
+import { getDocument, putDocument } from "./kv";
+
+describe("recovering from a failed open()", () => {
+  it("does not cache a rejection -- a later call can still succeed", async () => {
+    // Fails the first indexedDB.open() the module makes, standing in for a
+    // real failure (onblocked losing a race with another tab, for one). If
+    // kv.ts cached that rejected promise, every subsequent call in the
+    // session -- getDocument, putDocument, presets, settings -- would reject
+    // forever with this same error, not just the call that hit it.
+    const openSpy = jest.spyOn(indexedDB, "open").mockImplementationOnce(() => {
+      const request = {
+        error: new Error("simulated open failure"),
+        onblocked: null,
+        onerror: null as (() => void) | null,
+        onsuccess: null,
+        onupgradeneeded: null,
+        result: undefined,
+      };
+      // Deferred so kv.ts's open() has finished assigning request.onerror
+      // before it fires, the same way a real IDBOpenDBRequest's events do.
+      queueMicrotask(() => request.onerror?.());
+      return request as unknown as IDBOpenDBRequest;
+    });
+
+    await expect(getDocument("anything")).rejects.toThrow(
+      "simulated open failure"
+    );
+
+    // The mock only overrides the first call; this one reaches the real
+    // fake-indexeddb and should succeed if -- and only if -- kv.ts asked for
+    // a fresh open() rather than reusing the rejected promise above.
+    await putDocument("recovered", { ok: true });
+    await expect(getDocument("recovered")).resolves.toEqual({ ok: true });
+
+    openSpy.mockRestore();
+  });
+});

--- a/src/lib/storage/kv-upgrade.test.ts
+++ b/src/lib/storage/kv-upgrade.test.ts
@@ -47,9 +47,11 @@ describe("the version 1 to 2 upgrade", () => {
       request.onerror = () => reject(request.error);
     });
 
-    // kv.ts caches its connection at module load; drop it so the next call
-    // opens the database above at version 2 and runs onupgradeneeded fresh,
-    // the same way a real app relaunch would.
+    // kv.ts opens lazily on first call, not at module load, and nothing in
+    // this file has called into it yet -- so there is no cached connection
+    // for this to drop. It is kept anyway, defensively: it costs nothing,
+    // and it stops this test from silently depending on being the first
+    // caller if a later change adds one before it.
     resetConnectionForTests();
 
     await expect(getDocument("doc")).resolves.toEqual({ name: "existing" });

--- a/src/lib/storage/kv-upgrade.test.ts
+++ b/src/lib/storage/kv-upgrade.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The version 1 to 2 upgrade, in its own file.
+ *
+ * `kv.test.ts` and every other test that imports `./kv` opens the database at
+ * the current `DATABASE_VERSION` as its first act, which would leave nothing
+ * at version 1 left to upgrade from by the time this ran. Jest gives each
+ * test file its own module registry, and `fake-indexeddb/auto` seeds a fresh
+ * in-memory `indexedDB` per registry, so being alone in this file is what
+ * guarantees the database does not already exist above version 1 when the
+ * test below creates it.
+ */
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "@jest/globals";
+import { blobKeys, getDocument, getFile, resetConnectionForTests } from "./kv";
+
+describe("the version 1 to 2 upgrade", () => {
+  it("keeps existing data and adds the blobs store", async () => {
+    // Simulates a real user's database: created at version 1, holding a
+    // document and a file, before this module ever opens it. The name is
+    // hardcoded rather than imported, because it pins the address the big
+    // comment above DATABASE in kv.ts says must never change -- if that
+    // constant were ever edited, this test should still open the database
+    // real users have on disk today.
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open("hdri-calibration", 1);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        database.createObjectStore("documents");
+        database.createObjectStore("files");
+      };
+      request.onsuccess = () => {
+        const database = request.result;
+        const transaction = database.transaction(
+          ["documents", "files"],
+          "readwrite"
+        );
+        transaction.objectStore("documents").put({ name: "existing" }, "doc");
+        transaction
+          .objectStore("files")
+          .put(new Uint8Array([1, 2, 3]).buffer, "file");
+        transaction.oncomplete = () => {
+          database.close();
+          resolve();
+        };
+        transaction.onerror = () => reject(transaction.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    // kv.ts caches its connection at module load; drop it so the next call
+    // opens the database above at version 2 and runs onupgradeneeded fresh,
+    // the same way a real app relaunch would.
+    resetConnectionForTests();
+
+    await expect(getDocument("doc")).resolves.toEqual({ name: "existing" });
+    await expect(getFile("file")).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    // Proves blobs was created on the upgrade path, not only the
+    // fresh-database path every other test in this suite takes.
+    await expect(blobKeys()).resolves.toEqual([]);
+  });
+});

--- a/src/lib/storage/kv-version-downgrade.test.ts
+++ b/src/lib/storage/kv-version-downgrade.test.ts
@@ -1,0 +1,36 @@
+/**
+ * F1: opening at a version lower than what's already on disk, in its own
+ * file for the same module-registry-isolation reason as `kv-upgrade.test.ts`
+ * -- every other test file that imports `./kv` opens the shared fake
+ * database at `DATABASE_VERSION` as its first act, which would leave nothing
+ * at a higher version left for this test to downgrade from.
+ */
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "@jest/globals";
+import { DatabaseVersionError, getDocument } from "./kv";
+
+describe("opening at a version lower than what's on disk", () => {
+  it("rejects with DatabaseVersionError rather than a generic error", async () => {
+    // Stands in for a rolled-back deploy, a stale HTTP-cached bundle, or a
+    // reinstalled older desktop build: something else already upgraded this
+    // database past DATABASE_VERSION (2) before this module's open() ever
+    // runs.
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open("hdri-calibration", 3);
+      request.onupgradeneeded = () => {
+        // Nothing to create; only that the database ends up at version 3.
+      };
+      request.onsuccess = () => {
+        request.result.close();
+        resolve();
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    const error = await getDocument("anything").catch(
+      (caught: unknown) => caught
+    );
+    expect(error).toBeInstanceOf(DatabaseVersionError);
+    expect((error as Error).name).toBe("DatabaseVersionError");
+  });
+});

--- a/src/lib/storage/kv-versionchange-recovery.test.ts
+++ b/src/lib/storage/kv-versionchange-recovery.test.ts
@@ -1,0 +1,67 @@
+/**
+ * F4: a call after onversionchange must succeed by reopening, not fail
+ * forever. In its own file so this test's own trigger for onversionchange
+ * (an explicit open at version 3) does not collide with the one in
+ * `kv-versionchange.test.ts` -- each Jest test file gets its own
+ * `fake-indexeddb` registry, so the database this test bumps to version 3
+ * is not the same one another file already bumped.
+ */
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "@jest/globals";
+import { getDocument, putDocument } from "./kv";
+
+const TEST_TIMEOUT_MS = 5000;
+
+describe("recovering from onversionchange", () => {
+  it(
+    "reopens rather than failing forever once the old connection is closed",
+    async () => {
+      // The fault this guards against: closing the database in
+      // onversionchange without also clearing kv.ts's cached `connection`
+      // leaves that module-level variable resolved to a closed handle. Every
+      // call into kv.ts after that point would then reject with
+      // InvalidStateError permanently -- not just the call that raced the
+      // version change -- since nothing else ever clears the cache.
+      // app-storage.ts's readJson swallows read errors and returns the
+      // fallback, so that failure would not surface as an error to the
+      // user; it would render as an empty app -- no presets, no settings,
+      // no run history -- until the tab is reloaded.
+      await putDocument("before", { survives: true });
+
+      // Triggers this tab's onversionchange by opening at a higher version,
+      // the same way kv-versionchange.test.ts does -- but aborts the
+      // upgrade transaction rather than letting it complete. Per the
+      // IndexedDB spec an aborted upgrade rolls the database's version back
+      // to what it was; letting it complete would leave the shared fake
+      // database at version 3 forever, and kv.ts always asks for
+      // DATABASE_VERSION (2), so a later call in *this test* would fail with
+      // VersionError for a reason that has nothing to do with what F4 is
+      // about. The versionchange event this test cares about has already
+      // fired on kv.ts's connection by the time onupgradeneeded runs here,
+      // so aborting after that point still exercises the fix.
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open("hdri-calibration", 3);
+        request.onupgradeneeded = () => {
+          request.transaction?.abort();
+        };
+        request.onsuccess = () => {
+          request.result.close();
+          reject(new Error("expected the upgrade to abort"));
+        };
+        request.onerror = () => resolve();
+      });
+
+      // The behaviour that actually matters is not that onversionchange
+      // called close() -- it is that a caller on the other side of that
+      // event still gets a working database, by reopening, rather than
+      // InvalidStateError from a connection nothing ever replaced.
+      await expect(getDocument("before")).resolves.toEqual({
+        survives: true,
+      });
+      await expect(
+        putDocument("after", { alsoWorks: true })
+      ).resolves.toBeDefined();
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/src/lib/storage/kv-versionchange.test.ts
+++ b/src/lib/storage/kv-versionchange.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Whether an existing connection yields to a newer tab's upgrade, in its own
+ * file for the same module-registry-isolation reason as `kv-upgrade.test.ts`.
+ */
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "@jest/globals";
+import { getDocument } from "./kv";
+
+describe("onversionchange", () => {
+  it("closes kv.ts's connection so a newer open() is not blocked", async () => {
+    // Establishes kv.ts's cached connection at DATABASE_VERSION (2), the
+    // same as an already-open tab.
+    await getDocument("anything");
+
+    // Stands in for a newer tab's kv.ts loading a build with a higher
+    // DATABASE_VERSION. Without the fix, this hangs on onblocked, because
+    // kv.ts's connection above never closes to let it proceed.
+    const opened = await new Promise<{ blocked: boolean; version: number }>(
+      (resolve, reject) => {
+        let blocked = false;
+        const request = indexedDB.open("hdri-calibration", 3);
+        request.onupgradeneeded = () => {
+          // Nothing to create; only whether the upgrade transaction starts
+          // at all is under test here.
+        };
+        request.onblocked = () => {
+          blocked = true;
+        };
+        request.onsuccess = () => {
+          const database = request.result;
+          database.close();
+          resolve({ blocked, version: database.version });
+        };
+        request.onerror = () => reject(request.error);
+      }
+    );
+
+    expect(opened.blocked).toBe(false);
+    expect(opened.version).toBe(3);
+  });
+});

--- a/src/lib/storage/kv-versionchange.test.ts
+++ b/src/lib/storage/kv-versionchange.test.ts
@@ -1,41 +1,61 @@
 /**
  * Whether an existing connection yields to a newer tab's upgrade, in its own
  * file for the same module-registry-isolation reason as `kv-upgrade.test.ts`.
+ * (The recovery half of this fix, F4, is in `kv-versionchange-recovery.test.ts`
+ * rather than a second `it` here, because this test leaves the underlying
+ * fake database bumped to version 3 -- a second test in this same registry
+ * that needed kv.ts to reopen at version 2 would immediately fail with
+ * VersionError, not because of anything under test, but because of the
+ * version this test itself left behind.)
+ *
+ * A regression here tends to read as a hang rather than a failing assertion
+ * -- the production `open()` promise this exercises simply never settles,
+ * because it deadlocks on the newer tab's `onblocked`. That was verified by
+ * hand while building this fix: removing `onversionchange` made this test
+ * run past Jest's tool-level timeout with no output. The explicit per-test
+ * timeout below turns that into a red test in a few seconds rather than a
+ * run that has to be killed.
  */
 import "fake-indexeddb/auto";
 import { describe, expect, it } from "@jest/globals";
 import { getDocument } from "./kv";
 
+const TEST_TIMEOUT_MS = 5000;
+
 describe("onversionchange", () => {
-  it("closes kv.ts's connection so a newer open() is not blocked", async () => {
-    // Establishes kv.ts's cached connection at DATABASE_VERSION (2), the
-    // same as an already-open tab.
-    await getDocument("anything");
+  it(
+    "closes kv.ts's connection so a newer open() is not blocked",
+    async () => {
+      // Establishes kv.ts's cached connection at DATABASE_VERSION (2), the
+      // same as an already-open tab.
+      await getDocument("anything");
 
-    // Stands in for a newer tab's kv.ts loading a build with a higher
-    // DATABASE_VERSION. Without the fix, this hangs on onblocked, because
-    // kv.ts's connection above never closes to let it proceed.
-    const opened = await new Promise<{ blocked: boolean; version: number }>(
-      (resolve, reject) => {
-        let blocked = false;
-        const request = indexedDB.open("hdri-calibration", 3);
-        request.onupgradeneeded = () => {
-          // Nothing to create; only whether the upgrade transaction starts
-          // at all is under test here.
-        };
-        request.onblocked = () => {
-          blocked = true;
-        };
-        request.onsuccess = () => {
-          const database = request.result;
-          database.close();
-          resolve({ blocked, version: database.version });
-        };
-        request.onerror = () => reject(request.error);
-      }
-    );
+      // Stands in for a newer tab's kv.ts loading a build with a higher
+      // DATABASE_VERSION. Without the fix, this hangs on onblocked, because
+      // kv.ts's connection above never closes to let it proceed.
+      const opened = await new Promise<{ blocked: boolean; version: number }>(
+        (resolve, reject) => {
+          let blocked = false;
+          const request = indexedDB.open("hdri-calibration", 3);
+          request.onupgradeneeded = () => {
+            // Nothing to create; only whether the upgrade transaction starts
+            // at all is under test here.
+          };
+          request.onblocked = () => {
+            blocked = true;
+          };
+          request.onsuccess = () => {
+            const database = request.result;
+            database.close();
+            resolve({ blocked, version: database.version });
+          };
+          request.onerror = () => reject(request.error);
+        }
+      );
 
-    expect(opened.blocked).toBe(false);
-    expect(opened.version).toBe(3);
-  });
+      expect(opened.blocked).toBe(false);
+      expect(opened.version).toBe(3);
+    },
+    TEST_TIMEOUT_MS
+  );
 });

--- a/src/lib/storage/kv.test.ts
+++ b/src/lib/storage/kv.test.ts
@@ -1,0 +1,37 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "@jest/globals";
+import { getDocument, putDocument, updateDocument } from "./kv";
+
+describe("updateDocument", () => {
+  it("creates a document when none exists", async () => {
+    const written = await updateDocument<number[]>("counter-a", (current) => [
+      ...(current ?? []),
+      1,
+    ]);
+    expect(written).toEqual([1]);
+    expect(await getDocument<number[]>("counter-a")).toEqual([1]);
+  });
+
+  it("applies the change to the stored value", async () => {
+    await putDocument("counter-b", [1, 2]);
+    const written = await updateDocument<number[]>("counter-b", (current) => [
+      ...(current ?? []),
+      3,
+    ]);
+    expect(written).toEqual([1, 2, 3]);
+  });
+
+  it("does not lose concurrent updates", async () => {
+    await putDocument("counter-c", []);
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((value) =>
+        updateDocument<number[]>("counter-c", (current) => [
+          ...(current ?? []),
+          value,
+        ])
+      )
+    );
+    const stored = await getDocument<number[]>("counter-c");
+    expect(stored).toHaveLength(5);
+  });
+});

--- a/src/lib/storage/kv.ts
+++ b/src/lib/storage/kv.ts
@@ -103,6 +103,42 @@ export function deleteDocument(key: string): Promise<unknown> {
 }
 
 /**
+ * Reads, changes and writes a document inside one transaction.
+ *
+ * `run()` issues a single request per transaction, so `getDocument` followed
+ * by `putDocument` is two transactions with a window between them. The RAW
+ * cache index is written by the worker on every conversion and cleared from
+ * the settings page, and a lost update there means a leaked blob nothing will
+ * ever evict.
+ */
+export function updateDocument<T>(
+  key: string,
+  change: (current: T | undefined) => T
+): Promise<T> {
+  return open().then(
+    (database) =>
+      new Promise<T>((resolve, reject) => {
+        const transaction = database.transaction(DOCUMENTS, "readwrite");
+        const store = transaction.objectStore(DOCUMENTS);
+        const read = store.get(key);
+        let written: T;
+        read.onsuccess = () => {
+          written = change(read.result as T | undefined);
+          store.put(written, key);
+        };
+        read.onerror = () =>
+          reject(read.error ?? new Error(`${DOCUMENTS}: read failed`));
+        // Resolved on the transaction, not the put: the write is only durable
+        // once the transaction commits, and a quota abort can follow a
+        // successful request.
+        transaction.oncomplete = () => resolve(written);
+        transaction.onabort = () =>
+          reject(transaction.error ?? new Error(`${DOCUMENTS}: aborted`));
+      })
+  );
+}
+
+/**
  * Reads a stored file.
  *
  * Returns a fresh view each time. IndexedDB structured-clones on the way out,

--- a/src/lib/storage/kv.ts
+++ b/src/lib/storage/kv.ts
@@ -30,12 +30,14 @@
  * Cosmetic renames are free; addresses are not.
  */
 const DATABASE = "hdri-calibration";
-const DATABASE_VERSION = 1;
+const DATABASE_VERSION = 2;
 
 /** JSON documents: settings, the preset index, run history. */
 const DOCUMENTS = "documents";
 /** Binary blobs: calibration files and response functions, by virtual path. */
 const FILES = "files";
+/** Converted RAW frames, by content-addressed key. See `raw-cache.ts`. */
+const BLOBS = "blobs";
 
 let connection: Promise<IDBDatabase> | undefined;
 
@@ -49,6 +51,9 @@ function open(): Promise<IDBDatabase> {
       }
       if (!database.objectStoreNames.contains(FILES)) {
         database.createObjectStore(FILES);
+      }
+      if (!database.objectStoreNames.contains(BLOBS)) {
+        database.createObjectStore(BLOBS);
       }
     };
     request.onsuccess = () => resolve(request.result);
@@ -180,6 +185,47 @@ export async function fileKeys(prefix: string): Promise<string[]> {
   return keys
     .filter((key): key is string => typeof key === "string")
     .filter((key) => key.startsWith(prefix));
+}
+
+/**
+ * Reads a cached blob.
+ *
+ * Separate from `getFile` despite the identical shape, because these live in
+ * their own store: the RAW cache evicts on a budget and is cleared wholesale
+ * from the settings page, and neither may touch a preset's calibration files.
+ */
+export async function getBlob(key: string): Promise<Uint8Array | undefined> {
+  const stored = await run<ArrayBuffer | undefined>(
+    BLOBS,
+    "readonly",
+    (store) => store.get(key)
+  );
+  return stored ? new Uint8Array(stored) : undefined;
+}
+
+export function putBlob(key: string, bytes: Uint8Array): Promise<unknown> {
+  // Stored as ArrayBuffer for the reason `putFile` gives: a view carries its
+  // offset and length, so a subarray of a larger buffer would be cloned whole.
+  return run(BLOBS, "readwrite", (store) =>
+    store.put(
+      bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      ) as ArrayBuffer,
+      key
+    )
+  );
+}
+
+export function deleteBlob(key: string): Promise<unknown> {
+  return run(BLOBS, "readwrite", (store) => store.delete(key));
+}
+
+export async function blobKeys(): Promise<string[]> {
+  const keys = await run<IDBValidKey[]>(BLOBS, "readonly", (store) =>
+    store.getAllKeys()
+  );
+  return keys.filter((key): key is string => typeof key === "string");
 }
 
 /** Drops the cached connection. Tests only; the app opens once per session. */

--- a/src/lib/storage/kv.ts
+++ b/src/lib/storage/kv.ts
@@ -56,7 +56,16 @@ function open(): Promise<IDBDatabase> {
         database.createObjectStore(BLOBS);
       }
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      const database = request.result;
+      // Fires in an older tab when a newer tab's open() needs to upgrade.
+      // Closing here lets that upgrade proceed instead of leaving the newer
+      // tab's request permanently blocked -- DATABASE_VERSION could not
+      // change before this database had a second version to move between,
+      // so this branch was unreachable until the blob store was added.
+      database.onversionchange = () => database.close();
+      resolve(database);
+    };
     request.onerror = () =>
       reject(request.error ?? new Error("could not open IndexedDB"));
     // Fires when another tab holds an older version open. Rejecting is better
@@ -67,6 +76,16 @@ function open(): Promise<IDBDatabase> {
           "another tab is holding an older version of the database open"
         )
       );
+  }).catch((error: unknown) => {
+    // Not remembered: `??=` above means the first call to open() after a
+    // failure decides the value for every caller until the process reloads.
+    // A cached rejection would leave storage broken -- presets and settings,
+    // not just this cache -- until then, for a failure that may have been
+    // transient (an onblocked race resolved by the other tab closing, for
+    // one). `raw-cache-key.ts`'s `toolTag` and `wasm-runner.ts`'s compiled
+    // module cache clear their memo entries on failure for the same reason.
+    connection = undefined;
+    throw error;
   });
   return connection;
 }

--- a/src/lib/storage/kv.ts
+++ b/src/lib/storage/kv.ts
@@ -63,7 +63,21 @@ function open(): Promise<IDBDatabase> {
       // tab's request permanently blocked -- DATABASE_VERSION could not
       // change before this database had a second version to move between,
       // so this branch was unreachable until the blob store was added.
-      database.onversionchange = () => database.close();
+      //
+      // `connection` is cleared *before* `close()`, not after: this tab's
+      // cached promise still resolves to `database`, and once it is closed
+      // every later `getDocument`/`putDocument` against it fails with
+      // `InvalidStateError` -- permanently, since nothing else would ever
+      // clear the cache. `app-storage.ts`'s `readJson` swallows read errors
+      // and returns the fallback, so that failure would not surface as an
+      // error; it would render as an empty app -- no presets, no settings,
+      // no run history -- until the tab is reloaded. Clearing first means
+      // the next call to `open()` reopens instead of reusing the dying
+      // handle.
+      database.onversionchange = () => {
+        connection = undefined;
+        database.close();
+      };
       resolve(database);
     };
     request.onerror = () =>

--- a/src/lib/storage/kv.ts
+++ b/src/lib/storage/kv.ts
@@ -39,6 +39,33 @@ const FILES = "files";
 /** Converted RAW frames, by content-addressed key. See `raw-cache.ts`. */
 const BLOBS = "blobs";
 
+/**
+ * A stored database newer than this build knows how to open.
+ *
+ * IndexedDB does not negotiate a downgrade: opening at a version below what
+ * is already on disk fails the request with a `VersionError`, every time,
+ * for as long as the on-disk version stays ahead of `DATABASE_VERSION`. That
+ * is not a hypothetical -- a rolled-back web deploy, a browser still serving
+ * an old bundle from its HTTP cache, or a Tauri user reinstalling an older
+ * release all produce it for real, against data that is fully intact on
+ * disk. Left as a generic rejection, it looks identical to any other open
+ * failure: `app-storage.ts`'s `readJson` would swallow it and hand back the
+ * empty-state fallback, so the app would render as if the user had never
+ * used it, with no error anywhere to explain why. Giving it a name is what
+ * lets a caller refuse to paper over this one class of failure the way it is
+ * free to paper over the others.
+ */
+export class DatabaseVersionError extends Error {
+  constructor() {
+    super(
+      "This browser holds app data written by a newer version of LumiLab " +
+        "than this build can open. Reload the page, or update the app, to " +
+        "read it."
+    );
+    this.name = "DatabaseVersionError";
+  }
+}
+
 let connection: Promise<IDBDatabase> | undefined;
 
 function open(): Promise<IDBDatabase> {
@@ -80,8 +107,20 @@ function open(): Promise<IDBDatabase> {
       };
       resolve(database);
     };
-    request.onerror = () =>
-      reject(request.error ?? new Error("could not open IndexedDB"));
+    request.onerror = () => {
+      // A downgrade attempt surfaces here, not in onupgradeneeded: IndexedDB
+      // refuses it outright rather than running an upgrade transaction.
+      // Recognised by name rather than assumed from context, because this
+      // handler also catches every other open failure (onblocked losing a
+      // race is not modeled as an error here, but a future browser quirk
+      // could route through onerror too) and only this one is permanent for
+      // the life of the build.
+      reject(
+        request.error?.name === "VersionError"
+          ? new DatabaseVersionError()
+          : (request.error ?? new Error("could not open IndexedDB"))
+      );
+    };
     // Fires when another tab holds an older version open. Rejecting is better
     // than hanging: the caller reports it rather than the app appearing frozen.
     request.onblocked = () =>
@@ -98,6 +137,14 @@ function open(): Promise<IDBDatabase> {
     // transient (an onblocked race resolved by the other tab closing, for
     // one). `raw-cache-key.ts`'s `toolTag` and `wasm-runner.ts`'s compiled
     // module cache clear their memo entries on failure for the same reason.
+    //
+    // `DatabaseVersionError` is the one exception to "transient": the
+    // on-disk version really is ahead of `DATABASE_VERSION`, so retrying
+    // `open()` again fails identically until the running build changes.
+    // Clearing the cache here anyway is still correct -- it means a caller
+    // gets the same distinguishable error type on every retry rather than a
+    // stale cached rejection of a different shape -- and it costs nothing,
+    // since the retry that follows fails the same way either.
     connection = undefined;
     throw error;
   });


### PR DESCRIPTION
Closes #243.

RAW conversion is the most expensive thing this app does — about 2 s per 21.7 MB frame — and it was pure recomputation: the cache died with the tab, so reloading reconverted the whole bracket. The desktop build kept this on disk before the WebAssembly port and lost it, so this was a regression there as well as a gap in the browser.

## Result

| | first import | after reload | |
|---|---|---|---|
| 3 frames | 9,208 ms | **1,977 ms** | 4.7x |
| 10 frames | 25,715 ms | **5,198 ms** | 4.9x |
| control, cache disabled | 8,036 ms | 7,944 ms | none |

The control run rebuilds `raw-worker.ts` from its pre-cache parent and shows the second import staying exactly as slow. That is what makes this causal rather than correlational — the saving is the cache, not warm-up.

Measured by `e2e-web/tests/perf.bench.ts`, added here.

## Design

A persistent tier behind the existing in-memory session tier, inside the RAW worker. The worker already holds the source bytes, so it hashes them without a second read and the content hash never crosses back to the page.

**The key is `sha256(bytes) + "-" + toolTag`**, and both halves are correctness rather than optimisation:

- **Content hash, not path.** `registerSessionFile` mints `/session/<n>/<name>` from a counter that restarts each session, so the same path names *different bytes* across visits. A path-keyed cache would serve the wrong image.
- **A tool tag** over the `dcraw_emu` commit, the Emscripten version and the `dcrawArgs` flags. Without it, rebuilding the artifacts — which #244 automates — would serve pixels from a different demosaic while reporting success, breaking the byte-identical guarantee `raw-preview.ts` exists to hold.

## IndexedDB, not OPFS — measured, not assumed

#243 specified OPFS for its `createSyncAccessHandle` fast path. `e2e-web/tests/storage-probe.spec.ts` was written first to check that assumption, and CI found `navigator.storage.getDirectory` **absent** in WebKit and in WebKitGTK 605.1.15, the webview Tauri uses on Linux:

```
webkit:              opfsAvailable false, quota null, idb ok 298ms
WebKitGTK 605.1.15:  opfsAvailable false,              idb ok
Chromium:            OPFS ok
WebView2:            OPFS ok
```

Not slow, not quota-limited — not implemented. An OPFS cache would have silently never worked for Safari users or Linux desktop users. IndexedDB round-tripped 67 MB on every engine tested, and already backs presets, settings and run history in production.

The probe performs a **4-byte control write first** and reports a run inconclusive if that fails, because an earlier local failure that looked like a WebKit OPFS limit turned out to be a memory-starved host. That distinction is now permanent in the spec.

## Storage safety

This cache shares `hdri-calibration` with users' presets, settings and run history, and `app-storage.ts` swallows read errors into fallbacks — so storage failures render as *"you have no data"* rather than as errors. Three consequences were found in review and fixed here:

- **`DATABASE_VERSION` 1→2 made downgrade possible.** A rolled-back deploy, a cached bundle or an older Tauri reinstall opened at v1 against v2, threw `VersionError`, and showed an empty app with no error. Now surfaced as a distinguishable `DatabaseVersionError` the user actually sees.
- **`onversionchange` closed the database without clearing the cached connection**, so a tab left open across a deploy failed every later storage call permanently.
- **The 2 GB budget was never checked against the real quota.** Under a smaller quota the eviction loop never ran, writes threw and were swallowed, and the cache wedged forever while Settings reported nominal usage. The budget is now clamped to a share of `navigator.storage.estimate()`, `persist()` is requested, and a write failure triggers evict-and-retry.

## Also

- Settings reports cache usage against the **effective** budget, with a Clear button that keeps entries whose blobs it could not remove — so it cannot claim to have reclaimed disk it did not.
- The cache may never be the reason a conversion fails: every failure path falls through to converting.
- The cache write completes **before** `postMessage` transfers the buffer. A transfer detaches it, and caching after would persist a zero-byte blob that later reads as a successful hit — the failure class fixed in `93ba5fc`.

## Review

384 tests, 57 suites. Every task reviewed, then a whole-branch review, then a fix wave, then a scoped re-review that verified each fix by mutation rather than by trusting the report. Design and plan are in `docs/superpowers/specs/` and `docs/superpowers/plans/`.

**Known limitation, stated rather than hidden:** the first import ran above the 5,968 ms baseline measured earlier the same day. A single cache-off control also ran above it, which is consistent with environment slowness, but n=1 cannot rule out a first-import write cost. The design doc names the run that would settle it.

**Unrelated follow-ups found on the way:** `kv.ts`'s `run()` resolves on `request.onsuccess`, so a commit-time quota abort cannot reject — preset and settings writes can report success for a write that never committed. And #245's Windows hdrgen hang did not reproduce here (`End-to-end (windows-latest)` passed in 7m3s), which is worth revisiting on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)