### PR TITLE
Drop RAW conversions the user no longer wants (#248), and remove the frame they actually clicked (#251)

### DIFF
--- a/__tests__/image-matrix-selection-clear.test.tsx
+++ b/__tests__/image-matrix-selection-clear.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+
+declare const jest: typeof import("@jest/globals").jest;
+
+jest.mock("@tauri-apps/plugin-dialog", () => ({
+  open: () => Promise.resolve(null),
+}));
+jest.mock("@tauri-apps/plugin-fs", () => ({
+  readDir: () => Promise.resolve([]),
+  stat: () => Promise.resolve({ isDirectory: false, isFile: true, size: 1024 }),
+}));
+
+import {
+  SelectedImageProvider,
+  useSelectedImage,
+} from "../src/app/home-page/selected-image-context";
+import { ImageMatrixInput } from "../src/components/ui/image-matrix-input";
+import type { ImageSet } from "../src/components/ui/image-set-preview";
+import { TooltipProvider } from "../src/components/ui/tooltip";
+
+interface FormValues {
+  inputSets: ImageSet[];
+}
+
+// JPEGs rather than RAW files, for the same reason as `image-matrix-lock`: a
+// CR2 would drag the TIFF decode worker into a test about which file stays
+// selected.
+const SCENE1_FIRST = "/photos/scene1/capt01.jpg";
+const SCENE1_SECOND = "/photos/scene1/capt02.jpg";
+const SCENE2_ONLY = "/photos/scene2/capt03.jpg";
+
+const twoSets: ImageSet[] = [
+  { files: [SCENE1_FIRST, SCENE1_SECOND], name: "scene1" },
+  { files: [SCENE2_ONLY], name: "scene2" },
+];
+
+const NOTHING_SELECTED = "none";
+
+const REMOVE_SCENE1 = /remove image set scene1/i;
+const REMOVE_SCENE2 = /remove image set scene2/i;
+
+function SelectionProbe() {
+  const { selectedImage } = useSelectedImage();
+
+  return <p data-testid="selected">{selectedImage ?? NOTHING_SELECTED}</p>;
+}
+
+function Harness() {
+  const { control } = useForm<FormValues>({
+    defaultValues: { inputSets: twoSets.map((set) => ({ ...set })) },
+  });
+
+  return (
+    <TooltipProvider>
+      <SelectedImageProvider>
+        <ImageMatrixInput control={control} name="inputSets" />
+        <SelectionProbe />
+      </SelectedImageProvider>
+    </TooltipProvider>
+  );
+}
+
+const settle = () => act(() => new Promise((r) => setTimeout(r, 0)));
+
+async function renderPanel() {
+  // The file statistics resolve through a suspended child, so the first paint
+  // is awaited rather than taken synchronously.
+  let view: ReturnType<typeof render> | undefined;
+  await act(() => {
+    view = render(<Harness />);
+    return Promise.resolve();
+  });
+  await settle();
+  if (!view) {
+    throw new Error("expected the panel to render");
+  }
+
+  return view;
+}
+
+function thumbnails(container: HTMLElement): Element[] {
+  // One per file, in the order the rows render them, which is each set's files
+  // sorted -- the same order `onRemoveIndex` resolves against.
+  return Array.from(container.querySelectorAll(".generic-image-container"));
+}
+
+function thumbnailAt(container: HTMLElement, index: number): Element {
+  const thumbnail = thumbnails(container)[index];
+  if (!thumbnail) {
+    throw new Error(`expected a thumbnail at ${index}`);
+  }
+
+  return thumbnail;
+}
+
+async function selectThumbnail(container: HTMLElement, index: number) {
+  fireEvent.click(thumbnailAt(container, index));
+  await settle();
+}
+
+async function removeThumbnail(container: HTMLElement, index: number) {
+  // The context menu's trigger is the thumbnail wrapper, and a contextmenu
+  // event only bubbles up.
+  fireEvent.contextMenu(thumbnailAt(container, index));
+  await settle();
+  fireEvent.click(screen.getByText("Remove image"));
+  await settle();
+}
+
+function selected(): string {
+  const probe = screen.getByTestId("selected").textContent;
+
+  return probe ?? "";
+}
+
+describe("removing the file that is selected", () => {
+  // Left selected, the mask preview keeps asking for the dimensions of a frame
+  // the form no longer holds. For a RAW frame that is worse than stale: its
+  // queued conversion is dropped along with it, so the metadata promise the
+  // submit handler awaits rejects, and it is memoized on the path -- every
+  // later run awaits the same permanently rejected promise.
+  it("clears the selection when its whole set is removed", async () => {
+    const { container } = await renderPanel();
+
+    await selectThumbnail(container, 0);
+    expect(selected()).toBe(SCENE1_FIRST);
+
+    fireEvent.click(screen.getByRole("button", { name: REMOVE_SCENE1 }));
+    await settle();
+
+    expect(selected()).toBe(NOTHING_SELECTED);
+  });
+
+  it("clears the selection when that one frame is removed", async () => {
+    const { container } = await renderPanel();
+
+    await selectThumbnail(container, 0);
+    expect(selected()).toBe(SCENE1_FIRST);
+
+    await removeThumbnail(container, 0);
+
+    expect(selected()).toBe(NOTHING_SELECTED);
+  });
+});
+
+describe("removing a file that is not selected", () => {
+  // The clear has to be as narrow as the removal, or every removal anywhere in
+  // the panel would empty a preview the user is still working with.
+  it("keeps the selection when another set is removed", async () => {
+    const { container } = await renderPanel();
+
+    await selectThumbnail(container, 0);
+
+    fireEvent.click(screen.getByRole("button", { name: REMOVE_SCENE2 }));
+    await settle();
+
+    expect(selected()).toBe(SCENE1_FIRST);
+  });
+
+  it("keeps the selection when a sibling frame is removed", async () => {
+    const { container } = await renderPanel();
+
+    await selectThumbnail(container, 0);
+
+    await removeThumbnail(container, 1);
+
+    expect(selected()).toBe(SCENE1_FIRST);
+  });
+});

--- a/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
+++ b/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
@@ -295,7 +295,9 @@ EOF
 |---|---|---|---|
 | Queued, never sent | `false` | `false` | Abort and forget |
 | In flight | `true` | `false` | Leave entirely alone |
-| Finished | `true` | `true` | Leave entirely alone |
+| Finished | `true` or `false` | `true` | Leave entirely alone |
+
+`started` is not guaranteed on a finished frame: a converter may resolve without ever calling `onStart`, which is what #243's OPFS path does when it answers from a cached TIFF instead of converting. So `done` is what recognizes a finished entry, and the drop check has to test both flags rather than `started` alone.
 
 Forgetting an in-flight entry takes it out of the map while its conversion is still running, so re-adding the same set queues a *second* conversion of the same frame — the duplication this module caches the promise, rather than the result, to prevent. Leaning on the existing `catch → forget` instead fails the other way: a queued frame dropped and instantly re-added would hit the surviving entry and inherit its pending `AbortError`, showing a broken thumbnail for a file the user just asked for.
 
@@ -554,7 +556,11 @@ And the new export:
  * because forgetting it would make a re-added set a cache miss and convert
  * the same bytes a second time. A finished frame is kept too -- it costs
  * nothing the LRU budget does not already govern, and it makes re-adding the
- * same file instant.
+ * same file instant. `flags.done` is what recognizes it: a converter is free
+ * to resolve without ever calling `onStart` -- #243's OPFS path will do
+ * exactly that when it answers from a cached TIFF instead of converting --
+ * and such a converter would otherwise leave `flags.started` false on a
+ * completed entry, indistinguishable from one still queued.
  *
  * Paths that were never converted, including every non-RAW one, match no key
  * and cost a scan.
@@ -565,7 +571,7 @@ export function dropRawConversions(paths: string[]): void {
       if (key !== path && !key.startsWith(`${path}|`)) {
         continue;
       }
-      if (entry.flags.started) {
+      if (entry.flags.started || entry.flags.done) {
         continue;
       }
       entry.controller.abort();
@@ -641,10 +647,11 @@ Add `dropRawConversions` to the file's existing import from `./raw-preview`.
 
 - [ ] **Step 7: Verify the accounting case actually discriminates**
 
-The last case must fail without its guard. Temporarily delete these three lines from `rawToTiff`'s `.then`:
+The last case must fail without its guard. Temporarily delete the identity check from `rawToTiff`'s `.then` (keeping whatever the rest of the block needs to still compile):
 
 ```ts
-      if (cache.get(key) !== entry) {
+      const live = cache.get(key);
+      if (live?.flags !== flags) {
         return;
       }
 ```

--- a/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
+++ b/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
@@ -1,0 +1,806 @@
+# Drop RAW Conversions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A RAW frame the user has removed, and which has not yet reached the conversion worker, is never converted, so frames the user does want stop waiting behind it.
+
+**Architecture:** `raw-preview.ts` owns the session cache and gives each entry an `AbortController`. `raw-worker-client.ts` owns the serial queue and checks that signal once, at the front of the queue, immediately before `postMessage`. A frame already sent is left alone. The UI calls a single `dropRawConversions(paths)` and never learns a worker exists.
+
+**Tech Stack:** TypeScript, React 19, Jest (via `next/jest`, SWC transform), Biome through `ultracite`.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md`
+
+## Global Constraints
+
+- **Read the spec first.** It records why two of the three candidate designs were rejected, and re-proposing them wastes a review cycle.
+- **TDD, strictly.** Write the test, run it, watch it fail *for the stated reason*, then implement. A test that passes on first run is testing something that already worked — fix the test.
+- **Prose uses `--`, not an em dash.** Every comment in `src/lib/raw-*.ts` follows this. Match it.
+- **Comments explain why, not what.** This codebase's comments carry reasoning and consequences (see `raw-worker-client.ts:17-28`). Match that density; do not add narration.
+- **Run `npx jest <path>` for a single suite** and `npx jest` for all 58 suites before any commit.
+- **Run `npx ultracite check <files>` and `npx tsc --noEmit` before every commit.** Jest uses SWC and strips types without checking them, so a type error will not fail a test run.
+- **Conventional commits**, with the `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>` trailer.
+- **Branch:** work on `fix/raw-conversion-drop`, cut from `origin/main`.
+- Do not touch `raw-cache.ts`, `raw-cache-idb.ts`, or `raw-worker.ts`. #243's page/worker boundary is out of scope.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/lib/raw-worker-client.ts` | The single worker and its serial queue | Accept `RawConvertOptions`; check `signal` and fire `onStart` at the front of the queue |
+| `src/lib/raw-worker-client.test.ts` | Pins the serial invariant against a `FakeWorker` | Add three cases |
+| `src/lib/raw-preview.ts` | Session cache: dedup, fingerprint, LRU, accounting | Add `controller`/`started`/`done` to `Entry`; add `dropRawConversions`; make `forget` identity-aware; fix `held` accounting |
+| `src/lib/raw-preview.test.ts` | Pins the sharing guarantees | Add a deferred IO helper and four cases |
+| `src/components/ui/image-matrix-input.tsx` | Renders image sets and owns the form value | Fix the sorted/unsorted index bug; call `dropRawConversions` on both removal paths |
+
+Task 1 produces the type Task 2 consumes; Task 2 produces the function Task 3 calls. Each ends green and committable on its own.
+
+---
+
+## Task 1: Skip queued frames in the worker client
+
+**Files:**
+- Modify: `src/lib/raw-worker-client.ts:63-81`
+- Test: `src/lib/raw-worker-client.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  ```ts
+  export interface RawConvertOptions {
+    onStart?: () => void;
+    signal?: AbortSignal;
+  }
+
+  export function convertRawInWorker(
+    path: string,
+    bytes: Uint8Array,
+    wasmBaseUrl: string,
+    options?: RawConvertOptions
+  ): Promise<Uint8Array>;
+  ```
+  The type lives in `raw-worker-client.ts`, not `raw-worker.types.ts`: that file is for messages that cross `postMessage`, and neither a signal nor a callback can be structured-cloned.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/raw-worker-client.test.ts`, inside the existing `describe("driving the RAW worker")` block. Import `type RawConvertOptions` is not needed; the options object is inferred.
+
+```ts
+  it("never sends a queued frame whose signal was aborted", async () => {
+    install();
+    const controller = new AbortController();
+
+    const first = convertRawInWorker("/in/a.CR2", new Uint8Array([1]), "/wasm");
+    const dropped = convertRawInWorker(
+      "/in/b.CR2",
+      new Uint8Array([2]),
+      "/wasm",
+      { signal: controller.signal }
+    );
+    const third = convertRawInWorker("/in/c.CR2", new Uint8Array([3]), "/wasm");
+    await settle();
+
+    // Only `first` has been sent; the other two are still chained behind it.
+    expect(built[0]?.posts).toBe(1);
+
+    controller.abort();
+    pending[0]?.respond(new Uint8Array([9]));
+    await first;
+    await settle();
+    pending[1]?.respond(new Uint8Array([7]));
+    await settle();
+
+    // Two frames reached the worker, not three: `b` was skipped, so the
+    // second `postMessage` was `c`. Asserted on the count the worker actually
+    // saw rather than on a flag, so a frame that is merely *marked* dropped
+    // still fails here.
+    expect(built[0]?.posts).toBe(2);
+    await expect(dropped).rejects.toThrow(/abort/i);
+    await expect(third).resolves.toEqual(new Uint8Array([7]));
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/lib/raw-worker-client.test.ts -t "never sends a queued frame"`
+
+Expected: FAIL at `expect(built[0]?.posts).toBe(2)` with **"Expected: 2, Received: 3"**. Today the fourth argument is ignored, so `b` is sent, `pending[1]` is `b`'s response, and `c` is then sent as a third frame.
+
+If instead it fails with a timeout, the assertion order was changed — the count assertion must come before the two `await expect(...)` lines, because a promise that can never settle times out rather than failing usefully.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/lib/raw-worker-client.ts`, add the exported type above `convertRawInWorker`:
+
+```ts
+/**
+ * What a caller may say about a conversion beyond its inputs.
+ *
+ * Not in `raw-worker.types.ts` with the message shapes: neither a signal nor
+ * a callback survives `postMessage`, so these never cross into the worker.
+ * They govern whether the frame is sent at all, which is a decision this side
+ * makes.
+ */
+export interface RawConvertOptions {
+  /**
+   * Called once the frame is past the point of being skipped.
+   *
+   * `raw-preview.ts` cannot work this out for itself -- only the queue knows
+   * when a frame leaves it -- and it needs to, because dropping a frame that
+   * has already been sent must forget nothing.
+   */
+  onStart?: () => void;
+  /** Checked once, at the front of the queue. Aborting later does nothing. */
+  signal?: AbortSignal;
+}
+```
+
+Then change `convertRawInWorker`:
+
+```ts
+export function convertRawInWorker(
+  path: string,
+  bytes: Uint8Array,
+  wasmBaseUrl: string,
+  options?: RawConvertOptions
+): Promise<Uint8Array> {
+  const conversion = queue.then(() => {
+    // Checked here rather than when the call was made, which is the whole
+    // point: the work worth skipping is work that has been sitting in the
+    // queue. A signal already aborted on arrival takes this same path, so
+    // there is no second case for it.
+    if (options?.signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+    // Adjacent to the check on purpose. The instant a frame can no longer be
+    // skipped is the instant it counts as started, and nothing may run
+    // between the two that could throw and leave them disagreeing.
+    options?.onStart?.();
+    return send(path, bytes, wasmBaseUrl);
+  });
+  queue = conversion.then(
+    () => undefined,
+    () => undefined
+  );
+  return conversion;
+}
+```
+
+Leave the existing comment above `queue = conversion.then(...)` in place — it explains why the value is discarded on both paths, and that reasoning is unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx jest src/lib/raw-worker-client.test.ts`
+Expected: PASS, all cases in the file including the five that already existed.
+
+- [ ] **Step 5: Add the two companion cases**
+
+```ts
+  it("leaves a frame already in flight alone", async () => {
+    install();
+    const controller = new AbortController();
+
+    const conversion = convertRawInWorker(
+      "/in/a.CR2",
+      new Uint8Array([1]),
+      "/wasm",
+      { signal: controller.signal }
+    );
+    await settle();
+    expect(built[0]?.posts).toBe(1);
+
+    // Past the queue check, so the signal has nothing left to act on. The
+    // frame is shared -- the pipeline and the metadata reader may both be
+    // waiting on it -- so one consumer losing interest must not cancel it.
+    controller.abort();
+    pending[0]?.respond(new Uint8Array([9]));
+
+    await expect(conversion).resolves.toEqual(new Uint8Array([9]));
+    expect(built[0]?.terminated).toBe(false);
+  });
+
+  it("reports each frame as it leaves the queue", async () => {
+    install();
+    const started: string[] = [];
+
+    const first = convertRawInWorker(
+      "/in/a.CR2",
+      new Uint8Array([1]),
+      "/wasm",
+      { onStart: () => started.push("a") }
+    );
+    const second = convertRawInWorker(
+      "/in/b.CR2",
+      new Uint8Array([2]),
+      "/wasm",
+      { onStart: () => started.push("b") }
+    );
+    await settle();
+
+    // `b` is queued, not started. That distinction is what lets the cache
+    // forget a frame it can still skip and keep one it cannot.
+    expect(started).toEqual(["a"]);
+
+    pending[0]?.respond(new Uint8Array([9]));
+    await first;
+    await settle();
+    expect(started).toEqual(["a", "b"]);
+
+    pending[1]?.respond(new Uint8Array([8]));
+    await expect(second).resolves.toEqual(new Uint8Array([8]));
+  });
+```
+
+- [ ] **Step 6: Run the whole suite, lint and typecheck**
+
+```bash
+npx jest
+npx ultracite check src/lib/raw-worker-client.ts src/lib/raw-worker-client.test.ts
+npx tsc --noEmit
+```
+Expected: 58 suites pass (61 tests in total is not the number to check — check that nothing regressed), no lint findings, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/raw-worker-client.ts src/lib/raw-worker-client.test.ts
+git commit -m "$(cat <<'EOF'
+feat(raw): let the queue skip a frame nobody wants any more
+
+`convertRawInWorker` takes an optional signal, checked once at the front of
+the queue rather than when the call was made: the work worth skipping is the
+work that has been sitting in it. A skipped frame still occupies and settles
+its link, so ordering and the one-frame-at-a-time invariant are untouched,
+and `send()` is never entered -- no worker message, no interaction with
+`abandon`, no termination.
+
+`onStart` fires immediately after that check, because the cache on the other
+side of the seam cannot otherwise tell a queued frame from one already
+converting, and it must: forgetting the second kind would let a re-added set
+convert the same frame twice.
+
+Refs #248
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Three entry states and `dropRawConversions`
+
+**Files:**
+- Modify: `src/lib/raw-preview.ts` — `RawSourceIo` (:69-93), `Entry` (:95-99), `rawToTiff` (:112-148), `forget` (:176-182), `convert` (:184-199)
+- Test: `src/lib/raw-preview.test.ts`
+
+**Interfaces:**
+- Consumes: `RawConvertOptions` and the four-argument `convertRawInWorker` from Task 1.
+- Produces:
+  ```ts
+  export function dropRawConversions(paths: string[]): void;
+
+  // RawSourceIo.tiffFor, changed:
+  tiffFor?: (
+    path: string,
+    bytes: Uint8Array,
+    options?: { onStart?: () => void; signal?: AbortSignal }
+  ) => Promise<Uint8Array>;
+  ```
+
+**Background the implementer needs.** A frame has three states, and dropping treats the middle one *opposite* to how it treats the first:
+
+| State | `started` | `done` | On drop |
+|---|---|---|---|
+| Queued, never sent | `false` | `false` | Abort and forget |
+| In flight | `true` | `false` | Leave entirely alone |
+| Finished | `true` | `true` | Leave entirely alone |
+
+Forgetting an in-flight entry takes it out of the map while its conversion is still running, so re-adding the same set queues a *second* conversion of the same frame — the duplication this module caches the promise, rather than the result, to prevent. Leaning on the existing `catch → forget` instead fails the other way: a queued frame dropped and instantly re-added would hit the surviving entry and inherit its pending `AbortError`, showing a broken thumbnail for a file the user just asked for.
+
+- [ ] **Step 1: Add the deferred IO helper to the test file**
+
+`countingIo` resolves immediately, so it cannot model a frame that is in flight. Add alongside it in `src/lib/raw-preview.test.ts`:
+
+```ts
+/**
+ * An IO whose conversions finish only when the test says so.
+ *
+ * `countingIo` resolves on the spot, which cannot model the state that
+ * matters most here: a frame that has left the queue and is still converting.
+ * `start()` stands in for the queue handing the frame to the worker, so a
+ * test can place an entry in any of its three states deliberately.
+ */
+function deferredIo(): RawSourceIo & {
+  converted: string[];
+  finish: (path: string, bytes?: number) => void;
+  start: (path: string) => void;
+} {
+  const converted: string[] = [];
+  const starts = new Map<string, () => void>();
+  const finishes = new Map<string, (tiff: Uint8Array) => void>();
+  return {
+    converted,
+    finish: (path, bytes = 1024) => finishes.get(path)?.(new Uint8Array(bytes)),
+    readFile: () => Promise.resolve(new Uint8Array(64)),
+    start: (path) => starts.get(path)?.(),
+    tiffFor: (path, _bytes, options) => {
+      converted.push(path);
+      starts.set(path, () => options?.onStart?.());
+      return new Promise<Uint8Array>((resolve, reject) => {
+        finishes.set(path, resolve);
+        options?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError"))
+        );
+      });
+    },
+  };
+}
+```
+
+Note the contract this encodes: a converter calls `onStart` when its work stops being skippable. `workerTiffFor` gets this for free from the queue; a test-injected converter must say so itself, and one that never calls `onStart` leaves its frames droppable forever.
+
+- [ ] **Step 2: Write the failing test for the middle state**
+
+This is the case that discriminates the three-state model from the two-state one:
+
+```ts
+  it("converts a frame once even if it is dropped in flight and re-added", async () => {
+    const io = deferredIo();
+
+    const first = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+
+    // The user removes the set, then adds it back -- the wrong folder, or a
+    // re-drag. The frame is already converting, so dropping it must not
+    // forget it: a forgotten entry is a miss, and a miss here means a second
+    // conversion of bytes already being converted.
+    dropRawConversions(["/in/capt01.CR2"]);
+    const second = rawToTiff("/in/capt01.CR2", io);
+
+    io.finish("/in/capt01.CR2");
+    await expect(first).resolves.toHaveLength(1024);
+    await expect(second).resolves.toHaveLength(1024);
+    expect(io.converted).toEqual(["/in/capt01.CR2"]);
+  });
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `npx jest src/lib/raw-preview.test.ts -t "dropped in flight"`
+Expected: FAIL with **"dropRawConversions is not a function"** (it does not exist yet). Once it exists but forgets in-flight entries, this same test fails on the last line with `["/in/capt01.CR2", "/in/capt01.CR2"]` — keep that in mind, because that is the failure this test is really for.
+
+- [ ] **Step 4: Implement the entry states and the drop**
+
+In `src/lib/raw-preview.ts`, widen `RawSourceIo.tiffFor`:
+
+```ts
+  /**
+   * Converts one frame, given its path and its bytes.
+   *
+   * This is the seam, rather than the `ModuleLoader` it replaced, because
+   * conversion runs in a worker and a function cannot cross `postMessage`.
+   * Defaults to `workerTiffFor`, which drives that worker. Tests inject their
+   * own.
+   *
+   * Named for what it returns rather than what it does: under #243 it will
+   * often answer from OPFS without converting anything.
+   *
+   * `options.signal` lets a frame still waiting in the queue be skipped.
+   * `options.onStart` is the converter's half of that bargain: it says the
+   * frame can no longer be skipped, which is the only way this module can
+   * tell a queued frame from one already converting. A converter that never
+   * calls it leaves its frames droppable for their whole life.
+   */
+  tiffFor?: (
+    path: string,
+    bytes: Uint8Array,
+    options?: { onStart?: () => void; signal?: AbortSignal }
+  ) => Promise<Uint8Array>;
+```
+
+Forward from the default converter at `:47`:
+
+```ts
+/** The default converter: the worker. Tests inject their own. */
+function workerTiffFor(
+  path: string,
+  bytes: Uint8Array,
+  options?: RawConvertOptions
+): Promise<Uint8Array> {
+  return convertRawInWorker(path, bytes, wasmBaseUrl(), options);
+}
+```
+
+with `import { convertRawInWorker, type RawConvertOptions } from "./raw-worker-client";`.
+
+Widen `Entry`:
+
+```ts
+interface Entry {
+  /** Zero until the conversion resolves, so a pending entry evicts nothing. */
+  bytes: number;
+  /** Aborting this skips the frame, but only while it is still queued. */
+  controller: AbortController;
+  /** Set once the conversion settles, either way. */
+  done: boolean;
+  /** Set when the frame leaves the queue and reaches the worker. */
+  started: boolean;
+  tiff: Promise<Uint8Array<ArrayBuffer>>;
+}
+```
+
+`rawToTiff` builds the entry before starting the conversion, because `convert` needs to write `started` into it:
+
+```ts
+  const entry: Entry = {
+    bytes: 0,
+    controller: new AbortController(),
+    done: false,
+    started: false,
+    tiff: undefined as unknown as Promise<Uint8Array<ArrayBuffer>>,
+  };
+
+  const tiff = convert(path, io, entry).catch((error: unknown) => {
+    // A failure must not be remembered as a result, or the file could never
+    // be retried without a reload.
+    entry.done = true;
+    forget(key, entry);
+    throw error;
+  });
+  entry.tiff = tiff;
+  cache.set(key, entry);
+
+  tiff
+    .then((data) => {
+      entry.done = true;
+      // Only if this entry is still the live one for its key. An entry that
+      // left the map while converting -- evicted, or cleared -- must not add
+      // to `held`, because `forget` and `evictDownToBudget` both subtract
+      // `entry.bytes`, which was still 0 when they let it go. Accounting for
+      // it now would raise `held` permanently and make the budget evict ever
+      // more eagerly for the rest of the session.
+      if (cache.get(key) !== entry) {
+        return;
+      }
+      entry.bytes = data.byteLength;
+      held += data.byteLength;
+      evictDownToBudget(key);
+    })
+    .catch(() => {
+      // Handled above; this only prevents an unhandled rejection.
+    });
+
+  return tiff;
+```
+
+`convert` takes the entry and wires both callbacks:
+
+```ts
+async function convert(
+  path: string,
+  io: RawSourceIo,
+  entry: Entry
+): Promise<Uint8Array<ArrayBuffer>> {
+  const bytes = await io.readFile(path);
+  const tiff = await (io.tiffFor ?? workerTiffFor)(path, bytes, {
+    onStart: () => {
+      entry.started = true;
+    },
+    signal: entry.controller.signal,
+  });
+  // Never a SharedArrayBuffer -- these builds are single-threaded, which is
+  // what keeps them hostable without COOP/COEP headers, and a page served
+  // without those headers does not even define SharedArrayBuffer. The value
+  // now arrives by structured clone from the RAW worker rather than straight
+  // from MEMFS, but a cloned or transferred view is always ArrayBuffer-backed
+  // either way, so the narrowing still holds. Callers still owe `decodeTiff`
+  // a copy of `.buffer`, not a bare handoff: it does `buffer.slice(0)` before
+  // posting to the tiff worker.
+  return tiff as Uint8Array<ArrayBuffer>;
+}
+```
+
+`forget` becomes identity-aware:
+
+```ts
+/**
+ * Removes an entry, if it is still the one holding its key.
+ *
+ * The identity check is what keeps a dropped frame's `AbortError` -- which
+ * arrives at the `catch` above one turn later -- from deleting the *fresh*
+ * entry a user created by re-adding the same file in between. Without it,
+ * that replacement would be orphaned: still converting, no longer cached, and
+ * the next consumer to ask would start a third conversion.
+ */
+function forget(key: string, entry: Entry): void {
+  if (cache.get(key) !== entry) {
+    return;
+  }
+  held -= entry.bytes;
+  cache.delete(key);
+}
+```
+
+And the new export:
+
+```ts
+/**
+ * Gives up on frames the user has removed.
+ *
+ * Only frames still waiting in the queue are given up on. One already
+ * converting is left alone in both senses: it is not skipped, because the
+ * queue is past the point where that is possible, and it is not forgotten,
+ * because forgetting it would make a re-added set a cache miss and convert
+ * the same bytes a second time. A finished frame is kept too -- it costs
+ * nothing the LRU budget does not already govern, and it makes re-adding the
+ * same file instant.
+ *
+ * Paths that were never converted, including every non-RAW one, match no key
+ * and cost a scan.
+ */
+export function dropRawConversions(paths: string[]): void {
+  for (const path of paths) {
+    for (const [key, entry] of Array.from(cache.entries())) {
+      if (key !== path && !key.startsWith(`${path}|`)) {
+        continue;
+      }
+      if (entry.started) {
+        continue;
+      }
+      entry.controller.abort();
+      forget(key, entry);
+    }
+  }
+}
+```
+
+The key match covers both shapes `cacheKey` produces: `path` when there is no fingerprint, `path|fingerprint` when there is.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx jest src/lib/raw-preview.test.ts`
+Expected: PASS, including every case that already existed in the file.
+
+- [ ] **Step 6: Add the three remaining cases**
+
+```ts
+  it("forgets a frame dropped before it started, so a re-add converts it", async () => {
+    const io = deferredIo();
+
+    const dropped = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    // Deliberately no `io.start(...)`: this frame is still in the queue.
+    dropRawConversions(["/in/capt01.CR2"]);
+    await expect(dropped).rejects.toThrow(/abort/i);
+
+    const again = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+    io.finish("/in/capt01.CR2");
+
+    // A re-added file must convert, not inherit the rejection of the entry
+    // the user threw away.
+    await expect(again).resolves.toHaveLength(1024);
+    expect(io.converted).toHaveLength(2);
+  });
+
+  it("keeps a finished frame, so re-adding it is free", async () => {
+    const source = countingIo();
+
+    await rawToTiff("/in/capt01.CR2", source);
+    dropRawConversions(["/in/capt01.CR2"]);
+    await rawToTiff("/in/capt01.CR2", source);
+
+    // Removing a file is not a reason to throw away work already done: the
+    // LRU budget already governs how long it lives.
+    expect(source.converted).toHaveLength(1);
+  });
+
+  it("does not count a conversion that finished after its entry was gone", async () => {
+    const io = deferredIo();
+
+    const conversion = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+    clearRawPreviewCache();
+    io.finish("/in/capt01.CR2");
+    await conversion;
+
+    // `forget` and `evictDownToBudget` both subtract `entry.bytes`, which is
+    // 0 while a conversion is pending. Accounting for the bytes afterwards
+    // would leave `held` permanently ahead of what is actually cached, and a
+    // budget that thinks it is fuller than it is evicts frames it should
+    // have kept. Reached here through `clearRawPreviewCache` because the
+    // eviction path needs 768 MB of real allocation to trigger honestly.
+    expect(rawCacheBytes()).toBe(0);
+  });
+```
+
+Add `dropRawConversions` to the file's existing import from `./raw-preview`.
+
+- [ ] **Step 7: Verify the accounting case actually discriminates**
+
+The last case must fail without its guard. Temporarily delete these three lines from `rawToTiff`'s `.then`:
+
+```ts
+      if (cache.get(key) !== entry) {
+        return;
+      }
+```
+
+Run: `npx jest src/lib/raw-preview.test.ts -t "finished after its entry was gone"`
+Expected: FAIL with **"Expected: 0, Received: 1024"**.
+
+Restore the guard and re-run; expected PASS. Do not commit with the guard removed.
+
+- [ ] **Step 8: Run the whole suite, lint and typecheck**
+
+```bash
+npx jest
+npx ultracite check src/lib/raw-preview.ts src/lib/raw-preview.test.ts
+npx tsc --noEmit
+```
+Expected: all 58 suites pass, no findings, no type errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/raw-preview.ts src/lib/raw-preview.test.ts
+git commit -m "$(cat <<'EOF'
+feat(raw): give up on conversions the user has removed
+
+`dropRawConversions(paths)` abandons frames still waiting in the queue. A
+frame is one of three things, and the middle one is handled opposite to the
+first: queued frames are aborted and forgotten, frames already converting are
+left entirely alone, and finished frames are kept.
+
+Forgetting an in-flight frame would take its entry out of the map while its
+conversion ran, so re-adding the same set would miss and convert the same
+bytes twice -- the duplication this module caches the promise rather than the
+result to prevent. Relying instead on the existing `catch -> forget` fails
+the other way round: a queued frame dropped and immediately re-added would
+find the entry still there and inherit its pending AbortError, showing a
+failed thumbnail for a file the user had just asked for. Telling the two
+apart is what `onStart` is for.
+
+`forget` now checks identity before deleting, so a dropped frame's
+AbortError arriving a turn later cannot delete the replacement entry a re-add
+created in the meantime.
+
+Also fixes a pre-existing accounting leak this feature makes reachable. Both
+`forget` and `evictDownToBudget` subtract `entry.bytes`, which is 0 while a
+conversion is pending, so an entry that left the map before resolving added
+to `held` and never subtracted -- `held` drifting up for the rest of the
+session and the 768 MB budget evicting ever more eagerly. It needs two
+brackets in play at once, 673 MB each, which is precisely the swap-one-set-
+for-another flow this feature exists to serve.
+
+Refs #248
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire the UI, and fix the index it removes by
+
+**Files:**
+- Modify: `src/components/ui/image-matrix-input.tsx:212-242`
+
+**Interfaces:**
+- Consumes: `dropRawConversions(paths: string[]): void` from Task 2.
+- Produces: nothing later tasks depend on.
+
+**Background the implementer needs.** There is a pre-existing bug here, filed as #251, and the wiring is wrong without fixing it. `:214` passes `row.files.toSorted(...)` to `ImageSetPreview`, which maps over that sorted array and reports *its* index (`image-set-preview.tsx:112-136`). `:238` then applies that index to the **unsorted** `row.files`. The two agree only while the stored order happens to be sorted, and `onAdd` at `:216-230` appends, so adding any file that sorts before an existing one desynchronises them and every later removal deletes the wrong frame.
+
+- [ ] **Step 1: Read the current handlers**
+
+Read `src/components/ui/image-matrix-input.tsx:200-245`. There is no unit test for this component and none is added: the behaviour worth pinning lives in the two library modules, and this change is a call plus an index fix. Verification is by reading and by the e2e suite.
+
+- [ ] **Step 2: Hoist the sorted array and fix the index**
+
+Replace the `ImageSetPreview` element's `files` and `onRemoveIndex` props. Add above the `return` inside the `.map` callback, next to `const issue = ...`:
+
+```tsx
+          // The preview renders files sorted, and reports the index of what
+          // the user actually clicked. Resolving that index here, against the
+          // same array, is what keeps "remove this one" meaning the frame
+          // under the cursor rather than whichever one happens to sit at that
+          // position in the stored order. See #251.
+          const sorted = row.files.toSorted((a, b) => a.localeCompare(b));
+```
+
+Then:
+
+```tsx
+                files={sorted}
+```
+
+and:
+
+```tsx
+                onRemoveIndex={(deleteIndex) => {
+                  const removed = sorted[deleteIndex];
+                  dropRawConversions([removed]);
+                  value[index] = {
+                    ...row,
+                    // Filtered by identity rather than by writing `sorted`
+                    // back, which would also normalise the stored order on
+                    // the first removal -- a change `onAdd` would undo on the
+                    // next addition, so the array would flip between sorted
+                    // and not depending on which the user did last.
+                    files: row.files.filter((file) => file !== removed),
+                  };
+                  field.onChange([...value]);
+                }}
+```
+
+- [ ] **Step 3: Drop the whole set's frames on set removal**
+
+```tsx
+                onRemove={() => {
+                  dropRawConversions(row.files);
+                  field.onChange(value.filter((_, i) => i !== index));
+                }}
+```
+
+Add the import: `import { dropRawConversions } from "@/lib/raw-preview";`
+
+- [ ] **Step 4: Lint, typecheck and run the suite**
+
+```bash
+npx ultracite check src/components/ui/image-matrix-input.tsx
+npx tsc --noEmit
+npx jest
+```
+Expected: no findings, no type errors, all 58 suites pass.
+
+- [ ] **Step 5: Verify by hand against the reference bracket**
+
+The libraries are unit-tested; this step checks the wiring is actually connected. Run `npm run dev`, add the CR2 bracket, and confirm both:
+
+1. Remove the set two frames in. The remaining thumbnails for a *newly added* set should start appearing within about two seconds rather than after the removed set's frames finish. Before this change that wait was roughly 15 s for a 10-frame set.
+2. Add a file that sorts before an existing one, then remove a thumbnail by right-click. The frame that disappears must be the one that was clicked.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/ui/image-matrix-input.tsx
+git commit -m "$(cat <<'EOF'
+feat(raw): drop conversions when the user removes the frames
+
+Wires `dropRawConversions` into the two places that already know the user
+changed their mind. Removing a set two frames in no longer makes a newly
+added set wait about 15 s for frames nobody wants.
+
+Fixes the index those handlers removed by, which had to change for the
+wiring to be correct at all. The preview is handed a sorted copy and reports
+an index into it; `onRemoveIndex` applied that index to the unsorted stored
+array, so once `onAdd` appended a file that sorted earlier, removing an image
+deleted the wrong one -- and dropping the conversion for one frame while the
+form removed another would have left the cache and the UI disagreeing about
+which frame was gone. The index is now resolved against the array the user
+saw, and the file removed by identity so the stored order is left alone.
+
+Closes #248
+Closes #251
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section maps to a task: the "what cancel means" definition and the queue check to Task 1; the three-state table, `dropRawConversions`, identity-aware `forget`, the `tiffFor` seam, `workerTiffFor` forwarding and the accounting fix to Task 2; the wiring and the index bug to Task 3. The spec's error-handling section needs no task of its own — `AbortError` is thrown in Task 1 and the forget-on-drop behaviour is Task 2's. Out-of-scope items (#252, terminating in flight, reference counting) correctly have no tasks.
+
+**Type consistency.** `RawConvertOptions` is defined in Task 1 and consumed in Task 2. `dropRawConversions(paths: string[]): void` is defined in Task 2 and called in Task 3 with `[removed]` and `row.files`, both `string[]`. `Entry`'s `started`/`done`/`controller` are introduced and used only within Task 2. `tiffFor`'s options object is structurally identical to `RawConvertOptions` but written inline in `RawSourceIo`, deliberately: importing the worker client's type into the seam would tie the injectable interface to the worker implementation, which is what the seam exists to avoid.
+
+**One thing the implementer must not smooth over.** In Task 2 Step 4, `entry.tiff` is assigned after the entry is constructed, because `convert` needs the entry to write `started` into and the entry needs the promise. The `undefined as unknown as` cast is deliberate and load-bearing; a "cleaner" restructuring that passes a callback instead is fine, but leaving `tiff` optional on the interface is not — every reader of a cached entry would then have to handle a state that never occurs.

--- a/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
+++ b/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
@@ -16,7 +16,7 @@
 - **TDD, strictly.** Write the test, run it, watch it fail *for the stated reason*, then implement. A test that passes on first run is testing something that already worked — fix the test.
 - **Prose uses `--`, not an em dash.** Every comment in `src/lib/raw-*.ts` follows this. Match it.
 - **Comments explain why, not what.** This codebase's comments carry reasoning and consequences (see `raw-worker-client.ts:17-28`). Match that density; do not add narration.
-- **Run `npx jest <path>` for a single suite** and `npx jest` for all 58 suites before any commit.
+- **Run `npx jest <path>` for a single suite** and `npx jest` for the whole suite before any commit. The baseline on this branch before Task 1 is **57 suites / 384 tests**; each task should add tests and regress none. Do not derive the suite count from `--listTests`, which picks up shell-completion noise on this machine.
 - **Run `npx ultracite check <files>` and `npx tsc --noEmit` before every commit.** Jest uses SWC and strips types without checking them, so a type error will not fail a test run.
 - **Conventional commits**, with the `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>` trailer.
 - **Branch:** work on `fix/raw-conversion-drop`, cut from `origin/main`.
@@ -239,7 +239,7 @@ npx jest
 npx ultracite check src/lib/raw-worker-client.ts src/lib/raw-worker-client.test.ts
 npx tsc --noEmit
 ```
-Expected: 58 suites pass (61 tests in total is not the number to check — check that nothing regressed), no lint findings, no type errors.
+Expected: no regressions against the 57-suite / 384-test baseline (this task adds 3 tests), no lint findings, no type errors.
 
 - [ ] **Step 7: Commit**
 
@@ -661,7 +661,7 @@ npx jest
 npx ultracite check src/lib/raw-preview.ts src/lib/raw-preview.test.ts
 npx tsc --noEmit
 ```
-Expected: all 58 suites pass, no findings, no type errors.
+Expected: no regressions against the baseline, no findings, no type errors.
 
 - [ ] **Step 9: Commit**
 
@@ -776,7 +776,7 @@ npx ultracite check src/components/ui/image-matrix-input.tsx
 npx tsc --noEmit
 npx jest
 ```
-Expected: no findings, no type errors, all 58 suites pass.
+Expected: no findings, no type errors, no regressions against the baseline.
 
 - [ ] **Step 5: Verify by hand against the reference bracket**
 

--- a/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
+++ b/docs/superpowers/plans/2026-08-01-raw-conversion-cancellation.md
@@ -30,7 +30,7 @@
 |---|---|---|
 | `src/lib/raw-worker-client.ts` | The single worker and its serial queue | Accept `RawConvertOptions`; check `signal` and fire `onStart` at the front of the queue |
 | `src/lib/raw-worker-client.test.ts` | Pins the serial invariant against a `FakeWorker` | Add three cases |
-| `src/lib/raw-preview.ts` | Session cache: dedup, fingerprint, LRU, accounting | Add `controller`/`started`/`done` to `Entry`; add `dropRawConversions`; make `forget` identity-aware; fix `held` accounting |
+| `src/lib/raw-preview.ts` | Session cache: dedup, fingerprint, LRU, accounting | Add `controller` and an `EntryFlags` (`started`/`done`) to `Entry`; add `dropRawConversions`; make `forget` identity-aware; fix `held` accounting |
 | `src/lib/raw-preview.test.ts` | Pins the sharing guarantees | Add a deferred IO helper and four cases |
 | `src/components/ui/image-matrix-input.tsx` | Renders image sets and owns the form value | Fix the sorted/unsorted index bug; call `dropRawConversions` on both removal paths |
 
@@ -291,7 +291,7 @@ EOF
 
 **Background the implementer needs.** A frame has three states, and dropping treats the middle one *opposite* to how it treats the first:
 
-| State | `started` | `done` | On drop |
+| State | `flags.started` | `flags.done` | On drop |
 |---|---|---|---|
 | Queued, never sent | `false` | `false` | Abort and forget |
 | In flight | `true` | `false` | Leave entirely alone |
@@ -416,56 +416,67 @@ function workerTiffFor(
 
 with `import { convertRawInWorker, type RawConvertOptions } from "./raw-worker-client";`.
 
-Widen `Entry`:
+Widen `Entry`. The two mutable flags live in their own object so that
+`convert` can be handed something to write into *before* the entry exists —
+the entry needs the promise `convert` returns, so passing the entry itself
+would be circular and force a cast:
 
 ```ts
+/**
+ * What a conversion has done so far, separate from the entry so `convert`
+ * can be given it before the entry it will belong to exists.
+ */
+interface EntryFlags {
+  /** Set once the conversion settles, either way. */
+  done: boolean;
+  /** Set when the frame leaves the queue and reaches the worker. */
+  started: boolean;
+}
+
 interface Entry {
   /** Zero until the conversion resolves, so a pending entry evicts nothing. */
   bytes: number;
   /** Aborting this skips the frame, but only while it is still queued. */
   controller: AbortController;
-  /** Set once the conversion settles, either way. */
-  done: boolean;
-  /** Set when the frame leaves the queue and reaches the worker. */
-  started: boolean;
+  flags: EntryFlags;
   tiff: Promise<Uint8Array<ArrayBuffer>>;
 }
 ```
 
-`rawToTiff` builds the entry before starting the conversion, because `convert` needs to write `started` into it:
+`rawToTiff` then builds the flags and the controller first, and the entry once
+it has the promise:
 
 ```ts
-  const entry: Entry = {
-    bytes: 0,
-    controller: new AbortController(),
-    done: false,
-    started: false,
-    tiff: undefined as unknown as Promise<Uint8Array<ArrayBuffer>>,
-  };
+  const controller = new AbortController();
+  const flags: EntryFlags = { done: false, started: false };
 
-  const tiff = convert(path, io, entry).catch((error: unknown) => {
-    // A failure must not be remembered as a result, or the file could never
-    // be retried without a reload.
-    entry.done = true;
-    forget(key, entry);
-    throw error;
-  });
-  entry.tiff = tiff;
+  const tiff = convert(path, io, flags, controller.signal).catch(
+    (error: unknown) => {
+      // A failure must not be remembered as a result, or the file could never
+      // be retried without a reload.
+      flags.done = true;
+      forget(key, flags);
+      throw error;
+    }
+  );
+
+  const entry: Entry = { bytes: 0, controller, flags, tiff };
   cache.set(key, entry);
 
   tiff
     .then((data) => {
-      entry.done = true;
+      flags.done = true;
       // Only if this entry is still the live one for its key. An entry that
       // left the map while converting -- evicted, or cleared -- must not add
       // to `held`, because `forget` and `evictDownToBudget` both subtract
       // `entry.bytes`, which was still 0 when they let it go. Accounting for
       // it now would raise `held` permanently and make the budget evict ever
       // more eagerly for the rest of the session.
-      if (cache.get(key) !== entry) {
+      const live = cache.get(key);
+      if (live?.flags !== flags) {
         return;
       }
-      entry.bytes = data.byteLength;
+      live.bytes = data.byteLength;
       held += data.byteLength;
       evictDownToBudget(key);
     })
@@ -476,20 +487,22 @@ interface Entry {
   return tiff;
 ```
 
-`convert` takes the entry and wires both callbacks:
+`convert` takes the flags and the signal, not the entry — that is what keeps
+it callable before the entry exists:
 
 ```ts
 async function convert(
   path: string,
   io: RawSourceIo,
-  entry: Entry
+  flags: EntryFlags,
+  signal: AbortSignal
 ): Promise<Uint8Array<ArrayBuffer>> {
   const bytes = await io.readFile(path);
   const tiff = await (io.tiffFor ?? workerTiffFor)(path, bytes, {
     onStart: () => {
-      entry.started = true;
+      flags.started = true;
     },
-    signal: entry.controller.signal,
+    signal,
   });
   // Never a SharedArrayBuffer -- these builds are single-threaded, which is
   // what keeps them hostable without COOP/COEP headers, and a page served
@@ -509,14 +522,19 @@ async function convert(
 /**
  * Removes an entry, if it is still the one holding its key.
  *
- * The identity check is what keeps a dropped frame's `AbortError` -- which
- * arrives at the `catch` above one turn later -- from deleting the *fresh*
- * entry a user created by re-adding the same file in between. Without it,
- * that replacement would be orphaned: still converting, no longer cached, and
- * the next consumer to ask would start a third conversion.
+ * Identified by its flags rather than by the entry itself, so a conversion's
+ * own `catch` can call this without a forward reference to the entry it has
+ * not finished building. The two are one-to-one, so the check is the same.
+ *
+ * That check is what keeps a dropped frame's `AbortError` -- which arrives at
+ * the `catch` above one turn later -- from deleting the *fresh* entry a user
+ * created by re-adding the same file in between. Without it, that replacement
+ * would be orphaned: still converting, no longer cached, and the next
+ * consumer to ask would start a third conversion.
  */
-function forget(key: string, entry: Entry): void {
-  if (cache.get(key) !== entry) {
+function forget(key: string, flags: EntryFlags): void {
+  const entry = cache.get(key);
+  if (entry?.flags !== flags) {
     return;
   }
   held -= entry.bytes;
@@ -547,11 +565,11 @@ export function dropRawConversions(paths: string[]): void {
       if (key !== path && !key.startsWith(`${path}|`)) {
         continue;
       }
-      if (entry.started) {
+      if (entry.flags.started) {
         continue;
       }
       entry.controller.abort();
-      forget(key, entry);
+      forget(key, entry.flags);
     }
   }
 }
@@ -803,4 +821,4 @@ EOF
 
 **Type consistency.** `RawConvertOptions` is defined in Task 1 and consumed in Task 2. `dropRawConversions(paths: string[]): void` is defined in Task 2 and called in Task 3 with `[removed]` and `row.files`, both `string[]`. `Entry`'s `started`/`done`/`controller` are introduced and used only within Task 2. `tiffFor`'s options object is structurally identical to `RawConvertOptions` but written inline in `RawSourceIo`, deliberately: importing the worker client's type into the seam would tie the injectable interface to the worker implementation, which is what the seam exists to avoid.
 
-**One thing the implementer must not smooth over.** In Task 2 Step 4, `entry.tiff` is assigned after the entry is constructed, because `convert` needs the entry to write `started` into and the entry needs the promise. The `undefined as unknown as` cast is deliberate and load-bearing; a "cleaner" restructuring that passes a callback instead is fine, but leaving `tiff` optional on the interface is not — every reader of a cached entry would then have to handle a state that never occurs.
+**One thing the implementer must not smooth over.** In Task 2, the two mutable flags live in their own `EntryFlags` object rather than directly on `Entry`, and `forget` identifies an entry by that object rather than by the entry. This is not incidental style: `convert` must be handed something to write `started` into *before* the entry exists, because the entry needs the promise `convert` returns. Flattening the flags onto `Entry` reintroduces that circularity and forces either a cast on `tiff` or a forward reference to `entry` inside its own `catch`. Leaving `tiff` optional on the interface is not an acceptable escape either — every reader of a cached entry would then have to handle a state that never occurs.

--- a/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
@@ -154,16 +154,23 @@ inherit its pending `AbortError`, showing a failed thumbnail for a file the
 user just asked for. Forget-at-drop is right for queued and wrong for
 in-flight, so the two states have to be distinguishable.
 
-`Entry` therefore gains three fields:
+`Entry` therefore gains a controller and two flags. The flags live in their own
+object rather than directly on the entry, because `convert` has to be handed
+something to write `started` into *before* the entry exists -- the entry needs
+the promise `convert` returns:
 
 ```ts
-interface Entry {
-  bytes: number;
-  controller: AbortController;
+interface EntryFlags {
   /** Set once the conversion settles, either way. */
   done: boolean;
   /** Set when the frame leaves the queue and reaches the worker. */
   started: boolean;
+}
+
+interface Entry {
+  bytes: number;
+  controller: AbortController;
+  flags: EntryFlags;
   tiff: Promise<Uint8Array<ArrayBuffer>>;
 }
 ```
@@ -199,16 +206,26 @@ export function dropRawConversions(paths: string[]): void
 
 For each path it matches cache keys by `key === path || key.startsWith(
 `${path}|`)` — keys are `path` or `path|fingerprint` — and then applies the
-table above: an entry that has not `started` is aborted and forgotten;
-anything else is left untouched.
+table above: an entry that has neither `started` nor `done` is aborted and
+forgotten; anything else is left untouched.
+
+Both flags are tested, not `started` alone. A converter is free to resolve
+without ever calling `onStart` -- #243's OPFS path will do exactly that when it
+answers from a cached TIFF instead of converting -- and such a converter would
+leave `started` false on an entry that has already finished its work. Checking
+`started` alone would abort and forget that entry, throwing away a conversion
+that is complete.
 
 A finished conversion is deliberately kept rather than evicted. It costs
 nothing beyond the LRU budget that already governs it, and keeping it makes
 re-adding the same file instant instead of a re-queue. Non-RAW paths match no
 key, so callers need not filter by extension.
 
-`forget` becomes identity-aware, taking the entry it means to remove and
-deleting only if `cache.get(key) === entry`. Without that, a dropped frame's
+`forget` becomes identity-aware, taking the flags of the entry it means to
+remove and deleting only if `cache.get(key)?.flags === flags`. Identifying by
+the flags rather than by the entry lets a conversion's own `catch` call it
+without a forward reference to the entry it has not finished building; the two
+are one-to-one, so the check is the same. Without that check, a dropped frame's
 `AbortError` arriving at the `catch` on `:127` *after* the user has re-added
 the file would delete the replacement entry, orphaning a conversion that is
 already running and sending the next consumer to a third one.
@@ -245,18 +262,18 @@ The `.then` accounts only if the entry is still the live one for its key.
 
 ```ts
 .then((data) => {
-  entry.done = true;
-  if (cache.get(key) !== entry) {
+  flags.done = true;
+  const live = cache.get(key);
+  if (live?.flags !== flags) {
     return;               // dropped or evicted while converting
   }
-  entry.bytes = data.byteLength;
+  live.bytes = data.byteLength;
   held += data.byteLength;
   evictDownToBudget(key);
 })
 .catch(() => {
-  // Already handled at `:127`; this sets `done` on the failure path and
-  // prevents an unhandled rejection, as it did before.
-  entry.done = true;
+  // Handled at `:127`, which is also where `done` is set on the failure
+  // path; this only prevents an unhandled rejection, as it did before.
 })
 ```
 
@@ -323,11 +340,46 @@ drop time, and the existing `catch → forget` at `raw-preview.ts:127` covers
 the rejection that follows. A frame dropped and then re-added converts afresh
 rather than inheriting a rejected promise.
 
-No new unhandled-rejection surface: `raw-preview.ts:137` keeps a handler on
-the cached promise itself, and `tiff-image.tsx:50` already catches its derived
-promise because an aborted decode was always expected there. The thumbnail
-unmounts when its file is removed, so the `AbortError` does not reach the
-`ErrorBoundary` at `tiff-image.tsx:69`.
+**This section originally claimed there was no new unhandled-rejection
+surface, and it was wrong.** It enumerated two handlers -- `raw-preview.ts`'s
+own, on the cached promise, and `tiff-image.tsx:50`, on the derived decode
+promise -- and concluded that every consumer was covered. It missed a third
+consumer that also derives a promise from the cached one:
+`generic-image-metadata.ts`'s `getTiffImageMetadata`, which chains
+`rawToTiff(...).then(...)` to read the mask preview's dimensions. That promise
+had no rejection path at all, and making `AbortError` a routine outcome is
+exactly what turned the omission into two user-visible failures:
+
+- The submit handler at `page.tsx:440` awaits that promise outside its own
+  `try`, and it is memoized on the path -- so once it rejects, pressing Run did
+  nothing at all, with no toast and no recorded attempt, for as long as the
+  removed file stayed selected.
+- `lens-mask-input.tsx` and `fs-circular-mas-selection.tsx` read it with
+  `use()` inside a `Suspense` that has no `ErrorBoundary` above it anywhere.
+
+The cause underneath both is not the drop. It is that `selectedImage` was never
+cleared when the file it names is removed, so a path the form no longer
+contains went on driving the mask preview. What is true after the fix:
+
+- `image-matrix-input.tsx` clears the selection in `onRemove` and
+  `onRemoveIndex` when it points at a file being removed, so no consumer asks
+  for the metadata of a removed frame in the first place. The clear is as
+  narrow as the removal: removing some other set or sibling frame leaves the
+  selection alone.
+- `useGenericImageMetadata` attaches a swallowing handler where it memoizes the
+  promise, in the same spirit as `tiff-image.tsx:50`, so a metadata promise
+  created before the removal cannot surface as an unhandled rejection after the
+  selection has moved on. It returns the original promise, not the handled one:
+  a genuine conversion failure must still reject rather than look like an image
+  with no dimensions.
+
+The thumbnail itself unmounts when its file is removed, so the `AbortError`
+still does not reach the `ErrorBoundary` at `tiff-image.tsx:69`.
+
+No `ErrorBoundary` was added over the mask preview. One would be worth having
+on its own merits, but it addresses neither failure above -- the submit-handler
+one never throws during render -- and it is left as separate work rather than
+smuggled in as a fix for this.
 
 ## Testing
 
@@ -356,9 +408,16 @@ In `raw-preview.test.ts`:
   unit test. The entry point is tests-only, but the guard it exercises is the
   same one the eviction path needs, and it fails against today's code.
 
-The `image-matrix-input.tsx` wiring is not unit-tested; the behaviour worth
-pinning lives in the two library modules, and the component change is a
-two-line call plus the index fix.
+The `image-matrix-input.tsx` drop wiring itself is not unit-tested; the
+behaviour worth pinning there lives in the two library modules, and the
+component change is a two-line call plus the index fix.
+
+The selection clear that removal now performs *is* tested, in
+`__tests__/image-matrix-selection-clear.test.tsx`, against the same
+RTL-plus-react-hook-form harness `image-matrix-lock.test.tsx` uses. Four cases:
+the selection is cleared when its whole set is removed and when that one frame
+is removed, and it survives the removal of another set and of a sibling frame.
+The last two are what stop an unconditional clear from passing.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
@@ -1,0 +1,291 @@
+# Drop RAW conversions the user no longer wants
+
+**Status:** designed, not implemented
+**Date:** 2026-08-01
+**Closes:** [#248](https://github.com/radiantlab/LumiLab/issues/248)
+**Follows:** [#243](https://github.com/radiantlab/LumiLab/issues/243), which added the persistent tier this design deliberately does not touch
+
+## The problem
+
+RAW conversion runs one frame at a time in a dedicated worker. That serialism
+is deliberate: `WasmToolRunner.clear()` keeps its compiled modules, so one
+long-lived worker compiles `dcraw_emu` once and peaks at a single instance's
+~266 MiB, where a pool would compile per worker and multiply that peak.
+
+What the queue has no way to do is stop. `convertRawInWorker(path, bytes,
+wasmBaseUrl)` takes no signal and polls nothing.
+
+Because the queue is serial, frames nobody wants any more block frames
+somebody does. Remove a 10-frame CR2 set two frames in, or drop a set and add
+a different one, and the eight queued frames still convert before the first
+frame of the new set starts. That is about 15 s of thumbnails that appear to
+hang, on a path that was just fixed so it would stop appearing to hang.
+
+Both siblings already do better. `decodeTiff` takes an `AbortSignal` and
+terminates its worker on abort (`tiff-worker-client.ts:29-37`).
+`executeInWorker` polls `shouldStop` every 250 ms and terminates between
+stages. The RAW worker is the odd one out.
+
+## What #248 assumed, and what the code says
+
+#248 closed with a note worth correcting, because it would have argued this
+work down to nothing:
+
+> Once the worker grows an OPFS tier, a "queued" frame may turn out to be a
+> cache hit that costs milliseconds, which makes dropping it pointless.
+
+It does not. The persistent lookup lives *inside* the worker —
+`convertWithCache` runs in `raw-worker.ts:96`, reached only after the frame
+arrives by `postMessage`, which is to say after it has waited its entire turn
+in the queue. A frame that is a 5 ms cache hit still sits behind eight 1.9 s
+conversions.
+
+So dropping queued frames did not become pointless under #243. If anything the
+queue is now the only thing standing between a returning user and an instant
+thumbnail.
+
+That observation also implies a second, larger change — resolving cache hits
+*before* they queue — which is deliberately **out of scope here**. It means
+moving key derivation and the IndexedDB read out of the worker onto the page,
+or adding a peek message, and it reworks the boundary #243 has just
+established. It gets its own issue.
+
+## What "cancel" means here
+
+**A frame that has not yet been handed to the worker is never handed to it. A
+frame already converting runs to completion.**
+
+This is the cheapest of the three definitions #248 offered, and it recovers
+almost all of the benefit, because the waste is queue time rather than the
+~1.9 s in flight. It is also the only one that carries no risk to sharing:
+`rawToTiff` caches the promise rather than its result, so one entry serves
+three consumers — thumbnails via `use-tiff-bytes.tsx`, dimensions via
+`generic-image-metadata.ts`, and the pipeline via `peekRawTiff` — and one
+caller losing interest does not mean the frame is unwanted.
+
+The two rejected alternatives, recorded so they are not re-litigated:
+
+- **Terminate the in-flight frame.** `resetRawWorker()` already does this and
+  has no caller outside `onError`. It reclaims up to ~1.9 s more, but throws
+  away a frame the pipeline or the metadata reader may still be awaiting, and
+  forces a fresh `dcraw_emu` compile on the next frame. Worth revisiting only
+  if a case turns up where an in-flight frame is genuinely unwanted by
+  everyone.
+- **Reference-count the cache entry.** Correct in every case and the most
+  work: every consumer acquires and releases, and `peekRawTiff` currently
+  borrows without either. Not justified by a symptom that queue-skipping
+  already resolves.
+
+## Design
+
+### Ownership
+
+```
+image-matrix-input.tsx
+        │  dropRawConversions(paths)
+        ▼
+raw-preview.ts          owns the session cache and one controller per entry
+        │  signal
+        ▼
+raw-worker-client.ts    owns the queue, checks the signal before send()
+```
+
+The UI never learns that a worker or a queue exists, which is how it already
+reaches conversion — only through `rawToTiff`. `raw-preview.ts` is the only
+module that can both abort the conversion and forget the entry, so the drop
+API belongs there.
+
+### `raw-worker-client.ts`
+
+`convertRawInWorker` gains an optional `signal`:
+
+```ts
+const conversion = queue.then(() => {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+  return send(path, bytes, wasmBaseUrl);
+});
+```
+
+Checked at the front of the queue rather than at call time, which is the whole
+point: the work being skipped is work that has been waiting. A signal already
+aborted when `convertRawInWorker` is called is caught by the same check, so
+there is no second code path for it.
+
+A skipped frame still occupies its link in the chain and still settles it, so
+ordering and the one-frame-at-a-time invariant are untouched. `send()` is
+never entered, so there is no worker message, no interaction with `abandon`,
+and no termination.
+
+### `raw-preview.ts`
+
+`Entry` gains two fields:
+
+```ts
+interface Entry {
+  bytes: number;
+  controller: AbortController;
+  /** Set once the conversion settles, either way. */
+  done: boolean;
+  tiff: Promise<Uint8Array<ArrayBuffer>>;
+}
+```
+
+The controller belongs to the *entry*, not to a caller. That is what keeps
+sharing intact: there is exactly one conversion per frame and exactly one
+thing that can call it off, so no consumer can cancel a frame out from under
+the other two.
+
+`rawToTiff` passes `controller.signal` into `io.tiffFor`, whose signature gains
+the optional signal:
+
+```ts
+tiffFor?: (path: string, bytes: Uint8Array, signal?: AbortSignal)
+  => Promise<Uint8Array>;
+```
+
+New export:
+
+```ts
+export function dropRawConversions(paths: string[]): void
+```
+
+For each path, it matches cache keys by `key === path || key.startsWith(
+`${path}|`)` — keys are `path` or `path|fingerprint` — then, **only if the
+entry is not `done`**, aborts the controller and calls `forget(key)`.
+
+A finished conversion is deliberately kept. It costs nothing beyond the LRU
+budget that already governs it, and keeping it makes re-adding the same file
+instant instead of a re-queue. Non-RAW paths match no key, so callers need not
+filter by extension.
+
+### The accounting bug this uncovers
+
+`raw-preview.ts:137-141` accounts for a conversion when it resolves:
+
+```ts
+entry.bytes = data.byteLength;
+held += data.byteLength;
+```
+
+`forget()` and `evictDownToBudget()` both subtract `entry.bytes`, which is
+**0 while the entry is pending**. So any entry removed from the map before its
+conversion resolves adds to `held` and never subtracts. `held` drifts upward
+permanently and the 768 MB budget starts evicting far too eagerly.
+
+This is pre-existing and today needs an eviction to land on a pending entry,
+which is rare. **This design makes forgetting a pending entry the normal
+path**, so it would turn a latent leak into an everyday one. The fix belongs
+here rather than in a follow-up: the `.then` accounts only if the entry is
+still the live one for its key.
+
+```ts
+.then((data) => {
+  entry.done = true;
+  if (cache.get(key) !== entry) {
+    return;               // dropped or evicted while converting
+  }
+  entry.bytes = data.byteLength;
+  held += data.byteLength;
+  evictDownToBudget(key);
+})
+.catch(() => {
+  // Already handled at `:127`; this sets `done` on the failure path and
+  // prevents an unhandled rejection, as it did before.
+  entry.done = true;
+})
+```
+
+`done` is set on both paths. A conversion that failed is as finished as one
+that succeeded, and `dropRawConversions` must not try to abort either.
+
+### `image-matrix-input.tsx`
+
+Wired to the two places that already know the user changed their mind:
+
+- `onRemove` (the whole set) drops every file in the row.
+- `onRemoveIndex` drops the one file removed.
+
+### The index bug this uncovers
+
+`image-set-preview.tsx:112` maps over `files`, which `image-matrix-input.tsx:214`
+passes as `row.files.toSorted(...)`. `onRemoveIndex` at
+`image-matrix-input.tsx:238` then applies that index to the **unsorted**
+`row.files`. Removing an image therefore deletes the wrong frame whenever the
+stored order is not already sorted — which `onAdd` guarantees as soon as it
+appends a file that sorts before an existing one.
+
+This is a user-facing bug that predates this work, and it is fixed here rather
+than separately because the wiring is not correct without it: dropping the
+conversion for `sorted[i]` while the form removes `unsorted[i]` leaves the
+cache and the UI disagreeing about which frame is gone.
+
+Sort once and use the same array for both:
+
+```tsx
+const sorted = row.files.toSorted((a, b) => a.localeCompare(b));
+
+<ImageSetPreview
+  files={sorted}
+  onRemoveIndex={(i) => {
+    dropRawConversions([sorted[i]]);
+    value[index] = { ...row, files: sorted.filter((_, n) => n !== i) };
+    field.onChange([...value]);
+  }}
+/>
+```
+
+An issue is filed recording it independently, since it is worth a changelog
+line of its own and did not arrive with this feature.
+
+## Error handling
+
+A dropped frame rejects with a `DOMException` named `AbortError`, the same
+shape `decodeTiff` uses, so a deliberate drop stays distinguishable from a
+genuine conversion failure.
+
+It must not be remembered as a result. `dropRawConversions` calls `forget` at
+drop time, and the existing `catch → forget` at `raw-preview.ts:127` covers
+the rejection that follows. A frame dropped and then re-added converts afresh
+rather than inheriting a rejected promise.
+
+No new unhandled-rejection surface: `raw-preview.ts:137` keeps a handler on
+the cached promise itself, and `tiff-image.tsx:50` already catches its derived
+promise because an aborted decode was always expected there. The thumbnail
+unmounts when its file is removed, so the `AbortError` does not reach the
+`ErrorBoundary` at `tiff-image.tsx:69`.
+
+## Testing
+
+In `raw-worker-client.test.ts`, against the worker double that already pins
+the serial invariant:
+
+- A queued frame whose signal is aborted never reaches the worker. Asserted on
+  the double's received-message count, not on a flag, so a frame that is
+  merely *marked* dropped still fails the test.
+- The frames queued behind a skipped one still convert, in order.
+- A frame already in flight is unaffected by an abort and still resolves.
+
+In `raw-preview.test.ts`:
+
+- A dropped pending entry is forgotten, so a later request for the same path
+  converts again rather than returning the rejected promise.
+- A completed entry is not forgotten, so a re-add is served from memory.
+- `rawCacheBytes()` returns to zero after a dropped frame's conversion
+  settles. This is the guard on the accounting fix. It cannot be written
+  against today's code, which has no way to drop anything, so it must be
+  checked against a copy of the finished implementation with the
+  `cache.get(key) !== entry` guard removed — otherwise it pins nothing.
+
+The `image-matrix-input.tsx` wiring is not unit-tested; the behaviour worth
+pinning lives in the two library modules, and the component change is a
+two-line call plus the index fix.
+
+## Out of scope
+
+- Resolving persistent-cache hits before they queue. Its own issue.
+- Terminating in-flight conversions, and reference-counting cache entries.
+  Both rejected above, with reasons.
+- Any change to `raw-cache.ts`, `raw-cache-idb.ts`, or the worker's own
+  caching. #243's boundary is untouched.

--- a/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
@@ -48,7 +48,8 @@ That observation also implies a second, larger change — resolving cache hits
 *before* they queue — which is deliberately **out of scope here**. It means
 moving key derivation and the IndexedDB read out of the worker onto the page,
 or adding a peek message, and it reworks the boundary #243 has just
-established. It gets its own issue.
+established. Filed as
+[#252](https://github.com/radiantlab/LumiLab/issues/252).
 
 ## What "cancel" means here
 
@@ -97,16 +98,22 @@ API belongs there.
 
 ### `raw-worker-client.ts`
 
-`convertRawInWorker` gains an optional `signal`:
+`convertRawInWorker` gains an optional `options` argument carrying the signal
+and an `onStart` callback:
 
 ```ts
 const conversion = queue.then(() => {
-  if (signal?.aborted) {
+  if (options?.signal?.aborted) {
     throw new DOMException("Aborted", "AbortError");
   }
+  options?.onStart?.();
   return send(path, bytes, wasmBaseUrl);
 });
 ```
+
+The two lines are adjacent on purpose: the moment a frame is past the point of
+being skipped is the moment it counts as started, and nothing may run between
+them that could throw and leave the two disagreeing.
 
 Checked at the front of the queue rather than at call time, which is the whole
 point: the work being skipped is work that has been waiting. A signal already
@@ -120,7 +127,34 @@ and no termination.
 
 ### `raw-preview.ts`
 
-`Entry` gains two fields:
+A frame has **three** states, not two, and dropping treats each differently.
+Collapsing the middle one into the first is the mistake this section exists to
+avoid:
+
+| State | `started` | `done` | On drop |
+|---|---|---|---|
+| Queued, never sent | `false` | `false` | Abort and forget |
+| In flight | `true` | `false` | **Leave entirely alone** |
+| Finished | `true` | `true` | Leave entirely alone |
+
+The middle row is the one that bites. Aborting an in-flight frame is already a
+no-op, since the queue check has passed — but *forgetting* it takes the entry
+out of the map while its conversion is still running. Re-add the same set,
+which is exactly what #248 describes ("drop a set and add a different one",
+or the same one from the right folder), and the frame is a miss, so a
+**second** conversion of bytes already converting joins the queue. That is the
+duplication `rawToTiff` caches the promise rather than the result to prevent,
+in the module whose header calls itself "the only place a RAW file is
+demosaiced".
+
+Leaning on the existing `catch → forget` at `:127` instead of forgetting at
+drop time does not work either, and for the opposite reason: a *queued* frame
+that is dropped and immediately re-added would hit the still-present entry and
+inherit its pending `AbortError`, showing a failed thumbnail for a file the
+user just asked for. Forget-at-drop is right for queued and wrong for
+in-flight, so the two states have to be distinguishable.
+
+`Entry` therefore gains three fields:
 
 ```ts
 interface Entry {
@@ -128,6 +162,8 @@ interface Entry {
   controller: AbortController;
   /** Set once the conversion settles, either way. */
   done: boolean;
+  /** Set when the frame leaves the queue and reaches the worker. */
+  started: boolean;
   tiff: Promise<Uint8Array<ArrayBuffer>>;
 }
 ```
@@ -137,13 +173,23 @@ sharing intact: there is exactly one conversion per frame and exactly one
 thing that can call it off, so no consumer can cancel a frame out from under
 the other two.
 
-`rawToTiff` passes `controller.signal` into `io.tiffFor`, whose signature gains
-the optional signal:
+`started` cannot be inferred on this side of the seam — only the queue knows
+when a frame leaves it — so the seam carries a callback back. `RawSourceIo`'s
+`tiffFor` takes an options object rather than growing a third positional
+parameter:
 
 ```ts
-tiffFor?: (path: string, bytes: Uint8Array, signal?: AbortSignal)
-  => Promise<Uint8Array>;
+tiffFor?: (
+  path: string,
+  bytes: Uint8Array,
+  options?: { signal?: AbortSignal; onStart?: () => void }
+) => Promise<Uint8Array>;
 ```
+
+`workerTiffFor` at `raw-preview.ts:47` is the default implementation and must
+forward the options to `convertRawInWorker` — the signal reaches the queue
+check and `onStart` fires just past it. A test injecting its own `tiffFor` may
+ignore both, which is what makes the cache tests independent of the worker.
 
 New export:
 
@@ -151,14 +197,21 @@ New export:
 export function dropRawConversions(paths: string[]): void
 ```
 
-For each path, it matches cache keys by `key === path || key.startsWith(
-`${path}|`)` — keys are `path` or `path|fingerprint` — then, **only if the
-entry is not `done`**, aborts the controller and calls `forget(key)`.
+For each path it matches cache keys by `key === path || key.startsWith(
+`${path}|`)` — keys are `path` or `path|fingerprint` — and then applies the
+table above: an entry that has not `started` is aborted and forgotten;
+anything else is left untouched.
 
-A finished conversion is deliberately kept. It costs nothing beyond the LRU
-budget that already governs it, and keeping it makes re-adding the same file
-instant instead of a re-queue. Non-RAW paths match no key, so callers need not
-filter by extension.
+A finished conversion is deliberately kept rather than evicted. It costs
+nothing beyond the LRU budget that already governs it, and keeping it makes
+re-adding the same file instant instead of a re-queue. Non-RAW paths match no
+key, so callers need not filter by extension.
+
+`forget` becomes identity-aware, taking the entry it means to remove and
+deleting only if `cache.get(key) === entry`. Without that, a dropped frame's
+`AbortError` arriving at the `catch` on `:127` *after* the user has re-added
+the file would delete the replacement entry, orphaning a conversion that is
+already running and sending the next consumer to a third one.
 
 ### The accounting bug this uncovers
 
@@ -221,7 +274,8 @@ than separately because the wiring is not correct without it: dropping the
 conversion for `sorted[i]` while the form removes `unsorted[i]` leaves the
 cache and the UI disagreeing about which frame is gone.
 
-Sort once and use the same array for both:
+Sort once, and resolve the index against that same array to a *file*, then
+remove that file by identity:
 
 ```tsx
 const sorted = row.files.toSorted((a, b) => a.localeCompare(b));
@@ -229,15 +283,24 @@ const sorted = row.files.toSorted((a, b) => a.localeCompare(b));
 <ImageSetPreview
   files={sorted}
   onRemoveIndex={(i) => {
-    dropRawConversions([sorted[i]]);
-    value[index] = { ...row, files: sorted.filter((_, n) => n !== i) };
+    const removed = sorted[i];
+    dropRawConversions([removed]);
+    value[index] = { ...row, files: row.files.filter((f) => f !== removed) };
     field.onChange([...value]);
   }}
 />
 ```
 
-An issue is filed recording it independently, since it is worth a changelog
-line of its own and did not arrive with this feature.
+Filtering `row.files` by identity rather than writing `sorted` back is
+deliberate. Writing the sorted array back would also *normalize the stored
+order* on the first removal, which is a behaviour change beyond the bug —
+`onAdd` appends, so the stored array would flip between sorted and unsorted
+depending on which action the user took last. The index bug is fixed by making
+the index mean one thing; stored order is left exactly as it was.
+
+Filed independently as
+[#251](https://github.com/radiantlab/LumiLab/issues/251), since it is worth a
+changelog line of its own and did not arrive with this feature.
 
 ## Error handling
 
@@ -269,8 +332,12 @@ the serial invariant:
 
 In `raw-preview.test.ts`:
 
-- A dropped pending entry is forgotten, so a later request for the same path
+- A dropped queued entry is forgotten, so a later request for the same path
   converts again rather than returning the rejected promise.
+- **A frame dropped while in flight is converted exactly once even if it is
+  re-added.** This is the test for the three-state model: assert the injected
+  `tiffFor` was called once, not that the entry still exists, so a design that
+  forgets in-flight entries fails it.
 - A completed entry is not forgotten, so a re-add is served from memory.
 - `rawCacheBytes()` returns to zero after a dropped frame's conversion
   settles. This is the guard on the accounting fix. It cannot be written
@@ -284,7 +351,8 @@ two-line call plus the index fix.
 
 ## Out of scope
 
-- Resolving persistent-cache hits before they queue. Its own issue.
+- Resolving persistent-cache hits before they queue —
+  [#252](https://github.com/radiantlab/LumiLab/issues/252).
 - Terminating in-flight conversions, and reference-counting cache entries.
   Both rejected above, with reasons.
 - Any change to `raw-cache.ts`, `raw-cache-idb.ts`, or the worker's own

--- a/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md
@@ -227,11 +227,21 @@ held += data.byteLength;
 conversion resolves adds to `held` and never subtracts. `held` drifts upward
 permanently and the 768 MB budget starts evicting far too eagerly.
 
-This is pre-existing and today needs an eviction to land on a pending entry,
-which is rare. **This design makes forgetting a pending entry the normal
-path**, so it would turn a latent leak into an everyday one. The fix belongs
-here rather than in a follow-up: the `.then` accounts only if the entry is
-still the live one for its key.
+Dropping itself does **not** reach this. Under the three-state model only an
+entry that never started is forgotten, and such an entry rejects rather than
+resolving, so its accounting branch never runs. An earlier draft of this spec
+claimed dropping made the leak routine; that was true of the two-state design
+it was written against and is not true of this one.
+
+What reaches it is the flow this feature exists to serve. `evictDownToBudget`
+does not skip pending entries, and `BUDGET_BYTES` is 768 MB against a
+ten-frame bracket's 673 MB — so it takes two brackets in play at once for
+eviction to land on a frame that is still converting. Dropping one set and
+adding another is exactly that, and it is the scenario #248 opens with. The
+fix belongs here because this feature is what makes the flow common, not
+because dropping performs it.
+
+The `.then` accounts only if the entry is still the live one for its key.
 
 ```ts
 .then((data) => {
@@ -339,11 +349,12 @@ In `raw-preview.test.ts`:
   `tiffFor` was called once, not that the entry still exists, so a design that
   forgets in-flight entries fails it.
 - A completed entry is not forgotten, so a re-add is served from memory.
-- `rawCacheBytes()` returns to zero after a dropped frame's conversion
-  settles. This is the guard on the accounting fix. It cannot be written
-  against today's code, which has no way to drop anything, so it must be
-  checked against a copy of the finished implementation with the
-  `cache.get(key) !== entry` guard removed — otherwise it pins nothing.
+- `rawCacheBytes()` stays at zero when a conversion settles after its entry
+  has left the map. This is the guard on the accounting fix, and it is driven
+  through `clearRawPreviewCache()` rather than through eviction: reaching
+  `evictDownToBudget` honestly would mean allocating past a 768 MB budget in a
+  unit test. The entry point is tests-only, but the guard it exercises is the
+  same one the eviction path needs, and it fails against today's code.
 
 The `image-matrix-input.tsx` wiring is not unit-tested; the behaviour worth
 pinning lives in the two library modules, and the component change is a

--- a/src/app/home-page/selected-image-context.tsx
+++ b/src/app/home-page/selected-image-context.tsx
@@ -4,7 +4,15 @@ import { createContext, useContext, useMemo, useState } from "react";
 
 interface SelectedImageContextValue {
   selectedImage: string | undefined;
-  setSelectedImage: (image: string) => void;
+  /**
+   * Accepts `undefined` so a caller can clear the selection. Removing the file
+   * that is selected has to be able to say so: a path the form no longer
+   * contains must not go on driving the mask preview, whose metadata promise
+   * would then be resolved against a frame the user threw away -- and, for a
+   * RAW frame whose queued conversion was dropped with it, never resolve at
+   * all.
+   */
+  setSelectedImage: (image: string | undefined) => void;
 }
 
 const selectedImageContext = createContext<

--- a/src/components/ui/image-matrix-input.tsx
+++ b/src/components/ui/image-matrix-input.tsx
@@ -25,6 +25,7 @@ import {
 import { isTauri } from "@/lib/host/env";
 import { pickFiles, pickImageSets } from "@/lib/host/pick";
 import { imageFileExtensions } from "@/lib/image-file-extensions";
+import { dropRawConversions } from "@/lib/raw-preview";
 import { cn } from "@/lib/utils";
 import { Field, FieldContent, FieldError } from "./field";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
@@ -200,6 +201,12 @@ export function ImageMatrixInput<
       <FieldContent className="flex flex-col gap-0 divide-y overflow-y-auto">
         {value?.map((row: ImageSet, index: number) => {
           const issue = issuesByIndex?.[index];
+          // The preview renders files sorted, and reports the index of what
+          // the user actually clicked. Resolving that index here, against the
+          // same array, is what keeps "remove this one" meaning the frame
+          // under the cursor rather than whichever one happens to sit at that
+          // position in the stored order. See #251.
+          const sorted = row.files.toSorted((a, b) => a.localeCompare(b));
 
           return (
             <div
@@ -211,7 +218,7 @@ export function ImageMatrixInput<
             >
               <ImageSetPreview
                 disabled={disabled}
-                files={row.files.toSorted((a, b) => a.localeCompare(b))}
+                files={sorted}
                 name={row.name}
                 onAdd={async () => {
                   const newFiles = await pickFiles({
@@ -230,12 +237,26 @@ export function ImageMatrixInput<
                 }}
                 onClick={setSelectedImage}
                 onRemove={() => {
+                  dropRawConversions(row.files);
                   field.onChange(value.filter((_, i) => i !== index));
                 }}
                 onRemoveIndex={(deleteIndex) => {
+                  const removed = sorted[deleteIndex];
+                  // The preview maps over the array it was handed, so this
+                  // index is always in bounds -- the check is only what
+                  // `noUncheckedIndexedAccess` needs to see.
+                  if (removed === undefined) {
+                    return;
+                  }
+                  dropRawConversions([removed]);
                   value[index] = {
                     ...row,
-                    files: row.files.filter((_, i) => i !== deleteIndex),
+                    // Filtered by identity rather than by writing `sorted`
+                    // back, which would also normalise the stored order on
+                    // the first removal -- a change `onAdd` would undo on the
+                    // next addition, so the array would flip between sorted
+                    // and not depending on which the user did last.
+                    files: row.files.filter((file) => file !== removed),
                   };
                   field.onChange([...value]);
                 }}

--- a/src/components/ui/image-matrix-input.tsx
+++ b/src/components/ui/image-matrix-input.tsx
@@ -194,7 +194,7 @@ export function ImageMatrixInput<
     addSets(await pickImageSets({ directory: true, filters: imageFilters }));
   }, [addSets]);
 
-  const { setSelectedImage } = useSelectedImage();
+  const { selectedImage, setSelectedImage } = useSelectedImage();
 
   return (
     <Field className={className} data-invalid={fieldState.invalid}>
@@ -237,6 +237,17 @@ export function ImageMatrixInput<
                 }}
                 onClick={setSelectedImage}
                 onRemove={() => {
+                  // The mask preview points at a file, not at a set, so it has
+                  // to let go of one the user is deleting. Left alone it would
+                  // keep asking for the dimensions of a frame the form no
+                  // longer holds, and a RAW frame dropped from the queue below
+                  // never produces any.
+                  if (
+                    selectedImage !== undefined &&
+                    row.files.includes(selectedImage)
+                  ) {
+                    setSelectedImage(undefined);
+                  }
                   dropRawConversions(row.files);
                   field.onChange(value.filter((_, i) => i !== index));
                 }}
@@ -247,6 +258,11 @@ export function ImageMatrixInput<
                   // `noUncheckedIndexedAccess` needs to see.
                   if (removed === undefined) {
                     return;
+                  }
+                  // Same reason as `onRemove`, for the single frame this
+                  // removes.
+                  if (selectedImage === removed) {
+                    setSelectedImage(undefined);
                   }
                   dropRawConversions([removed]);
                   value[index] = {

--- a/src/lib/generic-image-metadata.ts
+++ b/src/lib/generic-image-metadata.ts
@@ -27,15 +27,29 @@ export function useGenericImageMetadata(
     if (!fsPath) {
       return;
     }
-    const kind: string = path.extname(fsPath).toLowerCase();
-    switch (kind) {
-      case ".jpg":
-      case ".jpeg":
-        return getJpegImageMetadata(fsPath);
-      default:
-        return getTiffImageMetadata(fsPath);
-    }
+    const metadata = metadataFor(fsPath);
+    // Removing a file drops its queued RAW conversion, and the rejection that
+    // causes arrives only once the queue reaches that frame -- by which time
+    // the selection has moved on and every consumer of this promise has
+    // unmounted, leaving nobody attached to it. Same reason as
+    // `tiff-image.tsx`'s handler on its derived decode promise. The original
+    // promise is returned, not the handled one: turning the rejection into a
+    // resolved `undefined` would make a genuine conversion failure look like
+    // an image with no dimensions.
+    metadata.catch(() => undefined);
+    return metadata;
   }, [fsPath]);
+}
+
+function metadataFor(fsPath: string): Promise<GenericImageMetadata> {
+  const kind: string = path.extname(fsPath).toLowerCase();
+  switch (kind) {
+    case ".jpg":
+    case ".jpeg":
+      return getJpegImageMetadata(fsPath);
+    default:
+      return getTiffImageMetadata(fsPath);
+  }
 }
 
 function getJpegImageMetadata(fsPath: string): Promise<GenericImageMetadata> {

--- a/src/lib/raw-preview.test.ts
+++ b/src/lib/raw-preview.test.ts
@@ -11,10 +11,14 @@
 import { beforeEach, describe, expect, it } from "@jest/globals";
 import {
   clearRawPreviewCache,
+  dropRawConversions,
   type RawSourceIo,
   rawCacheBytes,
   rawToTiff,
 } from "./raw-preview";
+
+// Hoisted per `useTopLevelRegex`: a regex literal in a test body fails lint.
+const ABORT_MESSAGE = /abort/i;
 
 /** Counts conversions, which is the whole point of the cache. */
 function countingIo(
@@ -29,6 +33,40 @@ function countingIo(
     tiffFor: (path: string) => {
       converted.push(path);
       return Promise.resolve(new Uint8Array(outputBytes));
+    },
+  };
+}
+
+/**
+ * An IO whose conversions finish only when the test says so.
+ *
+ * `countingIo` resolves on the spot, which cannot model the state that
+ * matters most here: a frame that has left the queue and is still converting.
+ * `start()` stands in for the queue handing the frame to the worker, so a
+ * test can place an entry in any of its three states deliberately.
+ */
+function deferredIo(): RawSourceIo & {
+  converted: string[];
+  finish: (path: string, bytes?: number) => void;
+  start: (path: string) => void;
+} {
+  const converted: string[] = [];
+  const starts = new Map<string, () => void>();
+  const finishes = new Map<string, (tiff: Uint8Array) => void>();
+  return {
+    converted,
+    finish: (path, bytes = 1024) => finishes.get(path)?.(new Uint8Array(bytes)),
+    readFile: () => Promise.resolve(new Uint8Array(64)),
+    start: (path) => starts.get(path)?.(),
+    tiffFor: (path, _bytes, options) => {
+      converted.push(path);
+      starts.set(path, () => options?.onStart?.());
+      return new Promise<Uint8Array>((resolve, reject) => {
+        finishes.set(path, resolve);
+        options?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError"))
+        );
+      });
     },
   };
 }
@@ -132,6 +170,86 @@ describe("shared RAW conversion", () => {
     expect(rawCacheBytes()).toBe(8192);
 
     clearRawPreviewCache();
+    expect(rawCacheBytes()).toBe(0);
+  });
+
+  it("converts a frame once even if it is dropped in flight and re-added", async () => {
+    const io = deferredIo();
+
+    const first = rawToTiff("/in/capt01.CR2", io);
+    // Two turns, not one: `rawToTiff` awaits the cache key, then `convert`
+    // awaits `readFile`, before it ever reaches `tiffFor`. One turn observes
+    // the frame still queued and calls a no-op `io.start`.
+    await Promise.resolve();
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+
+    // The user removes the set, then adds it back -- the wrong folder, or a
+    // re-drag. The frame is already converting, so dropping it must not
+    // forget it: a forgotten entry is a miss, and a miss here means a second
+    // conversion of bytes already being converted.
+    dropRawConversions(["/in/capt01.CR2"]);
+    const second = rawToTiff("/in/capt01.CR2", io);
+
+    io.finish("/in/capt01.CR2");
+    await expect(first).resolves.toHaveLength(1024);
+    await expect(second).resolves.toHaveLength(1024);
+    expect(io.converted).toEqual(["/in/capt01.CR2"]);
+  });
+
+  it("forgets a frame dropped before it started, so a re-add converts it", async () => {
+    const io = deferredIo();
+
+    const dropped = rawToTiff("/in/capt01.CR2", io);
+    // Two turns so `tiffFor` has actually run and registered its abort
+    // listener; deliberately no `io.start(...)`, so the frame is still in
+    // the queue when it is dropped.
+    await Promise.resolve();
+    await Promise.resolve();
+    dropRawConversions(["/in/capt01.CR2"]);
+    await expect(dropped).rejects.toThrow(ABORT_MESSAGE);
+
+    const again = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+    io.finish("/in/capt01.CR2");
+
+    // A re-added file must convert, not inherit the rejection of the entry
+    // the user threw away.
+    await expect(again).resolves.toHaveLength(1024);
+    expect(io.converted).toHaveLength(2);
+  });
+
+  it("keeps a finished frame, so re-adding it is free", async () => {
+    const source = countingIo();
+
+    await rawToTiff("/in/capt01.CR2", source);
+    dropRawConversions(["/in/capt01.CR2"]);
+    await rawToTiff("/in/capt01.CR2", source);
+
+    // Removing a file is not a reason to throw away work already done: the
+    // LRU budget already governs how long it lives.
+    expect(source.converted).toHaveLength(1);
+  });
+
+  it("does not count a conversion that finished after its entry was gone", async () => {
+    const io = deferredIo();
+
+    const conversion = rawToTiff("/in/capt01.CR2", io);
+    await Promise.resolve();
+    await Promise.resolve();
+    io.start("/in/capt01.CR2");
+    clearRawPreviewCache();
+    io.finish("/in/capt01.CR2");
+    await conversion;
+
+    // `forget` and `evictDownToBudget` both subtract `entry.bytes`, which is
+    // 0 while a conversion is pending. Accounting for the bytes afterwards
+    // would leave `held` permanently ahead of what is actually cached, and a
+    // budget that thinks it is fuller than it is evicts frames it should
+    // have kept. Reached here through `clearRawPreviewCache` because the
+    // eviction path needs 768 MB of real allocation to trigger honestly.
     expect(rawCacheBytes()).toBe(0);
   });
 });

--- a/src/lib/raw-preview.test.ts
+++ b/src/lib/raw-preview.test.ts
@@ -233,6 +233,43 @@ describe("shared RAW conversion", () => {
     expect(source.converted).toHaveLength(1);
   });
 
+  it("does not let a frame dropped and instantly re-added inherit the dropped entry's rejection or lose its own cache slot", async () => {
+    const io = deferredIo();
+    const path = "/in/capt01.CR2";
+
+    const dropped = rawToTiff(path, io);
+    // Two turns so `tiffFor` has run and the abort listener is attached
+    // before the drop, exactly as in the "forgets a frame dropped before it
+    // started" case above.
+    await Promise.resolve();
+    await Promise.resolve();
+    dropRawConversions([path]);
+    // No await between the drop and the re-add: that gap is what the earlier
+    // "forgets a frame dropped..." test could not exercise, because it
+    // awaited `dropped`'s rejection first, giving `rawToTiff`'s own
+    // `catch -> forget` time to clear the entry before the re-add ever ran.
+    const again = rawToTiff(path, io);
+    await expect(dropped).rejects.toThrow(ABORT_MESSAGE);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    io.start(path);
+    io.finish(path);
+    await expect(again).resolves.toHaveLength(1024);
+    expect(io.converted).toHaveLength(2);
+
+    // The replacement entry `again` created must still be the live cache
+    // entry for this key. Deliberately not awaited: if it were lost -- the
+    // dropped entry's late `forget` deleting it regardless of identity --
+    // this call starts a third, real conversion that nothing here ever
+    // finishes, and awaiting it would hang for 5 s instead of failing
+    // cleanly on `io.converted`'s length.
+    rawToTiff(path, io);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(io.converted).toHaveLength(2);
+  });
+
   it("does not count a conversion that finished after its entry was gone", async () => {
     const io = deferredIo();
 

--- a/src/lib/raw-preview.ts
+++ b/src/lib/raw-preview.ts
@@ -29,7 +29,10 @@
  * for a preview-only shortcut to reach for.
  */
 
-import { convertRawInWorker } from "./raw-worker-client";
+import {
+  convertRawInWorker,
+  type RawConvertOptions,
+} from "./raw-worker-client";
 
 /**
  * Where the browser builds are served from. See `public/wasm/README.md`.
@@ -44,8 +47,12 @@ function wasmBaseUrl(): string {
 }
 
 /** The default converter: the worker. Tests inject their own. */
-function workerTiffFor(path: string, bytes: Uint8Array): Promise<Uint8Array> {
-  return convertRawInWorker(path, bytes, wasmBaseUrl());
+function workerTiffFor(
+  path: string,
+  bytes: Uint8Array,
+  options?: RawConvertOptions
+): Promise<Uint8Array> {
+  return convertRawInWorker(path, bytes, wasmBaseUrl(), options);
 }
 
 /**
@@ -88,13 +95,37 @@ export interface RawSourceIo {
    *
    * Named for what it returns rather than what it does: under #243 it will
    * often answer from OPFS without converting anything.
+   *
+   * `options.signal` lets a frame still waiting in the queue be skipped.
+   * `options.onStart` is the converter's half of that bargain: it says the
+   * frame can no longer be skipped, which is the only way this module can
+   * tell a queued frame from one already converting. A converter that never
+   * calls it leaves its frames droppable for their whole life.
    */
-  tiffFor?: (path: string, bytes: Uint8Array) => Promise<Uint8Array>;
+  tiffFor?: (
+    path: string,
+    bytes: Uint8Array,
+    options?: { onStart?: () => void; signal?: AbortSignal }
+  ) => Promise<Uint8Array>;
+}
+
+/**
+ * What a conversion has done so far, separate from the entry so `convert`
+ * can be given it before the entry it will belong to exists.
+ */
+interface EntryFlags {
+  /** Set once the conversion settles, either way. */
+  done: boolean;
+  /** Set when the frame leaves the queue and reaches the worker. */
+  started: boolean;
 }
 
 interface Entry {
   /** Zero until the conversion resolves, so a pending entry evicts nothing. */
   bytes: number;
+  /** Aborting this skips the frame, but only while it is still queued. */
+  controller: AbortController;
+  flags: EntryFlags;
   tiff: Promise<Uint8Array<ArrayBuffer>>;
 }
 
@@ -124,19 +155,36 @@ export async function rawToTiff(
     return hit.tiff;
   }
 
-  const tiff = convert(path, io).catch((error: unknown) => {
-    // A failure must not be remembered as a result, or the file could never be
-    // retried without a reload.
-    forget(key);
-    throw error;
-  });
+  const controller = new AbortController();
+  const flags: EntryFlags = { done: false, started: false };
 
-  const entry: Entry = { bytes: 0, tiff };
+  const tiff = convert(path, io, flags, controller.signal).catch(
+    (error: unknown) => {
+      // A failure must not be remembered as a result, or the file could never
+      // be retried without a reload.
+      flags.done = true;
+      forget(key, flags);
+      throw error;
+    }
+  );
+
+  const entry: Entry = { bytes: 0, controller, flags, tiff };
   cache.set(key, entry);
 
   tiff
     .then((data) => {
-      entry.bytes = data.byteLength;
+      flags.done = true;
+      // Only if this entry is still the live one for its key. An entry that
+      // left the map while converting -- evicted, or cleared -- must not add
+      // to `held`, because `forget` and `evictDownToBudget` both subtract
+      // `entry.bytes`, which was still 0 when they let it go. Accounting for
+      // it now would raise `held` permanently and make the budget evict ever
+      // more eagerly for the rest of the session.
+      const live = cache.get(key);
+      if (live?.flags !== flags) {
+        return;
+      }
+      live.bytes = data.byteLength;
       held += data.byteLength;
       evictDownToBudget(key);
     })
@@ -173,20 +221,41 @@ function evictDownToBudget(keep: string): void {
   }
 }
 
-function forget(key: string): void {
+/**
+ * Removes an entry, if it is still the one holding its key.
+ *
+ * Identified by its flags rather than by the entry itself, so a conversion's
+ * own `catch` can call this without a forward reference to the entry it has
+ * not finished building. The two are one-to-one, so the check is the same.
+ *
+ * That check is what keeps a dropped frame's `AbortError` -- which arrives at
+ * the `catch` above one turn later -- from deleting the *fresh* entry a user
+ * created by re-adding the same file in between. Without it, that replacement
+ * would be orphaned: still converting, no longer cached, and the next
+ * consumer to ask would start a third conversion.
+ */
+function forget(key: string, flags: EntryFlags): void {
   const entry = cache.get(key);
-  if (entry) {
-    held -= entry.bytes;
-    cache.delete(key);
+  if (entry?.flags !== flags) {
+    return;
   }
+  held -= entry.bytes;
+  cache.delete(key);
 }
 
 async function convert(
   path: string,
-  io: RawSourceIo
+  io: RawSourceIo,
+  flags: EntryFlags,
+  signal: AbortSignal
 ): Promise<Uint8Array<ArrayBuffer>> {
   const bytes = await io.readFile(path);
-  const tiff = await (io.tiffFor ?? workerTiffFor)(path, bytes);
+  const tiff = await (io.tiffFor ?? workerTiffFor)(path, bytes, {
+    onStart: () => {
+      flags.started = true;
+    },
+    signal,
+  });
   // Never a SharedArrayBuffer -- these builds are single-threaded, which is
   // what keeps them hostable without COOP/COEP headers, and a page served
   // without those headers does not even define SharedArrayBuffer. The value
@@ -196,6 +265,38 @@ async function convert(
   // a copy of `.buffer`, not a bare handoff: it does `buffer.slice(0)` before
   // posting to the tiff worker.
   return tiff as Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * Gives up on frames the user has removed.
+ *
+ * Only frames still waiting in the queue are given up on. One already
+ * converting is left alone in both senses: it is not skipped, because the
+ * queue is past the point where that is possible, and it is not forgotten,
+ * because forgetting it would make a re-added set a cache miss and convert
+ * the same bytes a second time. A finished frame is kept too -- it costs
+ * nothing the LRU budget does not already govern, and it makes re-adding the
+ * same file instant. `flags.done` is what recognizes it: a converter that
+ * resolves without ever calling `onStart` -- `countingIo` in the tests --
+ * would otherwise leave `flags.started` false on a completed entry,
+ * indistinguishable from one still queued.
+ *
+ * Paths that were never converted, including every non-RAW one, match no key
+ * and cost a scan.
+ */
+export function dropRawConversions(paths: string[]): void {
+  for (const path of paths) {
+    for (const [key, entry] of Array.from(cache.entries())) {
+      if (key !== path && !key.startsWith(`${path}|`)) {
+        continue;
+      }
+      if (entry.flags.started || entry.flags.done) {
+        continue;
+      }
+      entry.controller.abort();
+      forget(key, entry.flags);
+    }
+  }
 }
 
 /**

--- a/src/lib/raw-preview.ts
+++ b/src/lib/raw-preview.ts
@@ -100,7 +100,9 @@ export interface RawSourceIo {
    * `options.onStart` is the converter's half of that bargain: it says the
    * frame can no longer be skipped, which is the only way this module can
    * tell a queued frame from one already converting. A converter that never
-   * calls it leaves its frames droppable for their whole life.
+   * calls it leaves its frames droppable until they finish -- see
+   * `dropRawConversions`, which keeps a settled entry by its `done` flag
+   * regardless of `started`.
    */
   tiffFor?: (
     path: string,
@@ -276,10 +278,11 @@ async function convert(
  * because forgetting it would make a re-added set a cache miss and convert
  * the same bytes a second time. A finished frame is kept too -- it costs
  * nothing the LRU budget does not already govern, and it makes re-adding the
- * same file instant. `flags.done` is what recognizes it: a converter that
- * resolves without ever calling `onStart` -- `countingIo` in the tests --
- * would otherwise leave `flags.started` false on a completed entry,
- * indistinguishable from one still queued.
+ * same file instant. `flags.done` is what recognizes it: a converter is free
+ * to resolve without ever calling `onStart` -- #243's OPFS path will do
+ * exactly that when it answers from a cached TIFF instead of converting --
+ * and such a converter would otherwise leave `flags.started` false on a
+ * completed entry, indistinguishable from one still queued.
  *
  * Paths that were never converted, including every non-RAW one, match no key
  * and cost a scan.

--- a/src/lib/raw-worker-client.test.ts
+++ b/src/lib/raw-worker-client.test.ts
@@ -23,6 +23,7 @@ interface Pending {
 /** Every worker the client has constructed, in order. */
 const built: FakeWorker[] = [];
 const pending: Pending[] = [];
+const ABORT_MESSAGE = /abort/i;
 
 class FakeWorker {
   private readonly listeners = new Map<string, ((event: unknown) => void)[]>();
@@ -228,5 +229,92 @@ describe("driving the RAW worker", () => {
     expect(built[1]?.posts).toBe(1);
     pending[1]?.respond(new Uint8Array([6]));
     await expect(second).resolves.toEqual(new Uint8Array([6]));
+  });
+
+  it("never sends a queued frame whose signal was aborted", async () => {
+    install();
+    const controller = new AbortController();
+
+    const first = convertRawInWorker("/in/a.CR2", new Uint8Array([1]), "/wasm");
+    const dropped = convertRawInWorker(
+      "/in/b.CR2",
+      new Uint8Array([2]),
+      "/wasm",
+      { signal: controller.signal }
+    );
+    const third = convertRawInWorker("/in/c.CR2", new Uint8Array([3]), "/wasm");
+    await settle();
+
+    // Only `first` has been sent; the other two are still chained behind it.
+    expect(built[0]?.posts).toBe(1);
+
+    controller.abort();
+    pending[0]?.respond(new Uint8Array([9]));
+    await first;
+    await settle();
+    pending[1]?.respond(new Uint8Array([7]));
+    await settle();
+
+    // Two frames reached the worker, not three: `b` was skipped, so the
+    // second `postMessage` was `c`. Asserted on the count the worker actually
+    // saw rather than on a flag, so a frame that is merely *marked* dropped
+    // still fails here.
+    expect(built[0]?.posts).toBe(2);
+    await expect(dropped).rejects.toThrow(ABORT_MESSAGE);
+    await expect(third).resolves.toEqual(new Uint8Array([7]));
+  });
+
+  it("leaves a frame already in flight alone", async () => {
+    install();
+    const controller = new AbortController();
+
+    const conversion = convertRawInWorker(
+      "/in/a.CR2",
+      new Uint8Array([1]),
+      "/wasm",
+      { signal: controller.signal }
+    );
+    await settle();
+    expect(built[0]?.posts).toBe(1);
+
+    // Past the queue check, so the signal has nothing left to act on. The
+    // frame is shared -- the pipeline and the metadata reader may both be
+    // waiting on it -- so one consumer losing interest must not cancel it.
+    controller.abort();
+    pending[0]?.respond(new Uint8Array([9]));
+
+    await expect(conversion).resolves.toEqual(new Uint8Array([9]));
+    expect(built[0]?.terminated).toBe(false);
+  });
+
+  it("reports each frame as it leaves the queue", async () => {
+    install();
+    const started: string[] = [];
+
+    const first = convertRawInWorker(
+      "/in/a.CR2",
+      new Uint8Array([1]),
+      "/wasm",
+      { onStart: () => started.push("a") }
+    );
+    const second = convertRawInWorker(
+      "/in/b.CR2",
+      new Uint8Array([2]),
+      "/wasm",
+      { onStart: () => started.push("b") }
+    );
+    await settle();
+
+    // `b` is queued, not started. That distinction is what lets the cache
+    // forget a frame it can still skip and keep one it cannot.
+    expect(started).toEqual(["a"]);
+
+    pending[0]?.respond(new Uint8Array([9]));
+    await first;
+    await settle();
+    expect(started).toEqual(["a", "b"]);
+
+    pending[1]?.respond(new Uint8Array([8]));
+    await expect(second).resolves.toEqual(new Uint8Array([8]));
   });
 });

--- a/src/lib/raw-worker-client.ts
+++ b/src/lib/raw-worker-client.ts
@@ -60,12 +60,47 @@ export function resetRawWorker(): void {
   abandon?.(new Error("the RAW worker was dropped"));
 }
 
+/**
+ * What a caller may say about a conversion beyond its inputs.
+ *
+ * Not in `raw-worker.types.ts` with the message shapes: neither a signal nor
+ * a callback survives `postMessage`, so these never cross into the worker.
+ * They govern whether the frame is sent at all, which is a decision this side
+ * makes.
+ */
+export interface RawConvertOptions {
+  /**
+   * Called once the frame is past the point of being skipped.
+   *
+   * `raw-preview.ts` cannot work this out for itself -- only the queue knows
+   * when a frame leaves it -- and it needs to, because dropping a frame that
+   * has already been sent must forget nothing.
+   */
+  onStart?: () => void;
+  /** Checked once, at the front of the queue. Aborting later does nothing. */
+  signal?: AbortSignal;
+}
+
 export function convertRawInWorker(
   path: string,
   bytes: Uint8Array,
-  wasmBaseUrl: string
+  wasmBaseUrl: string,
+  options?: RawConvertOptions
 ): Promise<Uint8Array> {
-  const conversion = queue.then(() => send(path, bytes, wasmBaseUrl));
+  const conversion = queue.then(() => {
+    // Checked here rather than when the call was made, which is the whole
+    // point: the work worth skipping is work that has been sitting in the
+    // queue. A signal already aborted on arrival takes this same path, so
+    // there is no second case for it.
+    if (options?.signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+    // Adjacent to the check on purpose. The instant a frame can no longer be
+    // skipped is the instant it counts as started, and nothing may run
+    // between the two that could throw and leave them disagreeing.
+    options?.onStart?.();
+    return send(path, bytes, wasmBaseUrl);
+  });
   // Discards the value on both paths, not just the error: `p.catch(fn)` is
   // `p.then(undefined, fn)`, so a fulfilled `conversion` would pass its ~67 MB
   // TIFF straight through and `queue` would pin it at module scope until the


### PR DESCRIPTION
Closes #248. Closes #251.

Design: `docs/superpowers/specs/2026-08-01-raw-conversion-cancellation-design.md`

## What it does

RAW conversion runs one frame at a time in a worker, because the wasm tool peaks at ~266 MiB per instance and `callMain` is synchronous. The queue had no way to stop, so frames nobody wants blocked frames somebody does: remove a 10-frame CR2 set two frames in, and a newly added set waited ~15 s for the eight discarded frames to convert first.

**"Cancel" here means: a frame not yet handed to the worker is never handed to it. A frame already converting runs to completion.** That is the cheapest of the three definitions #248 offered and recovers almost all of the benefit, because the waste is queue time rather than the ~1.9 s in flight. It also carries no risk to sharing -- `rawToTiff` caches the promise, so one entry serves thumbnails, image metadata and the pipeline, and one caller losing interest does not mean the frame is unwanted. The other two definitions are rejected in the spec, with reasons.

## Three states, not two

The middle state is handled opposite to the first:

| State | On drop |
|---|---|
| Queued, never sent | abort the signal **and** forget the entry |
| In flight | leave entirely alone |
| Finished | leave entirely alone |

Forgetting an in-flight entry removes it from the map while its conversion still runs, so re-adding the same set misses and converts the same bytes twice -- the duplication caching the promise exists to prevent. Relying instead on the existing `catch -> forget` fails the other way: a queued frame dropped and instantly re-added would find the entry still there and inherit its pending `AbortError`, showing a failed thumbnail for a file just asked for. Telling the two apart is what the `onStart` callback is for.

## Corrects an assumption in #248

#248 closed expecting the persistent tier to make this pointless, on the grounds that a queued frame might be a millisecond cache hit. It is not: `convertWithCache` runs *inside* the worker, so a hit is only discovered after the frame has waited its whole turn. Filed separately as #252.

## Two pre-existing bugs fixed because this work makes them reachable

**Wrong file deleted (#251).** `image-set-preview.tsx` reports an index into the *sorted* file list; `onRemoveIndex` applied it to the *unsorted* stored array. Desynchronised as soon as `onAdd` appends a file that sorts earlier. Not optional scope: dropping the conversion for `sorted[i]` while the form removes `unsorted[i]` would leave the cache and the UI disagreeing about which frame is gone. Fixed by resolving the index against the array the user saw and removing by identity, which leaves stored order untouched.

**`held` byte-accounting leak.** `forget` and `evictDownToBudget` subtract `entry.bytes`, which is 0 while pending, so an entry leaving the map before resolving inflated `held` permanently and made the 768 MB budget evict ever more eagerly. It takes two brackets in play at once (673 MB each) -- precisely the swap-one-set-for-another flow this feature serves.

## The finding worth reading

The whole-branch review caught a Critical defect the per-task reviews structurally could not, and which the spec had explicitly (and wrongly) ruled out.

`selectedImage` was never cleared when a file was removed. Click a thumbnail to set the mask preview, remove that set, add another, press Run -- and **nothing happens, permanently**. `page.tsx:440` awaits the metadata promise outside its try block, and the promise is `useMemo`-cached, so once it rejects with `AbortError` there is no toast, no run, and no feedback ever again. A second failure mode: `use()` on that promise under a `Suspense` with no `ErrorBoundary` above it, throwing during render.

Fixed at the root -- clear the selection when its file is removed, on both removal paths -- plus a swallowing handler so an orphaned metadata promise cannot surface as an unhandled rejection. Regression test in `__tests__/image-matrix-selection-clear.test.tsx`, verified to discriminate by reverting the fix and watching 2 of its 4 cases fail.

## Verification

58 suites / 396 tests pass; `tsc --noEmit` clean; `ultracite check` clean (the one remaining warning is in `src/lib/pipeline/orchestrator.ts`, pre-existing on `main`, in a file this branch does not touch).

Every guard added here was validated by mutation rather than by assertion -- delete the mechanism, watch the test fail, restore. That caught two mechanisms in the first round whose deletion left the whole suite green.

## Outstanding before merge

**Manual browser verification has not been done.** It needs a real CR2 bracket through a running dev server, to confirm two things: a newly added set's thumbnails start in ~2 s rather than ~15 s, and right-click-remove deletes the frame that was clicked.

## Known, deliberately not fixed

- The same path in two image sets is dropped for both, so the surviving set's thumbnail shows an aborted-load error until remount. Real but uncommon and non-corrupting; the spec's rejection of reference counting reasoned about the three consumer *types*, not about one path in two form rows. Worth its own issue.
- Removing one thumbnail removes every duplicate of that path within a set. Unreachable in practice -- `image-set-preview.tsx` keys the list by `key={file}`, so duplicates are already broken upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)