### PR TITLE
Show the lens mask whether or not a preview image is selected

### DIFF
--- a/__tests__/lens-mask-without-image.test.tsx
+++ b/__tests__/lens-mask-without-image.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, render, screen } from "@testing-library/react";
+import { motionValue } from "framer-motion";
+import { useForm } from "react-hook-form";
+
+// jest.mock must be hoisted above the imports below, which the SWC transform
+// only does for the global binding, not one imported from @jest/globals.
+declare const jest: typeof import("@jest/globals").jest;
+
+// The hook returns nothing when there is no path, which is the state under
+// test: no preview image has been clicked.
+jest.mock("@/lib/generic-image-metadata", () => ({
+  useGenericImageMetadata: (path?: string) =>
+    path ? Promise.resolve({ size: [5616, 3744] }) : undefined,
+}));
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { pipelineConfig } from "../src/app/pipeline/(pipeline-configuration)/config-provider";
+import { LensMaskInput } from "../src/app/pipeline/lens-mask-input";
+
+/** The mask a preset applies, in image pixels. */
+const PRESET_MASK = { radius: 1800, x: 2808, y: 1935 };
+
+/** The image the mocked metadata hook describes. */
+const PREVIEW_SIZE: [number, number] = [5616, 3744];
+
+const DRAWN_AGAINST = /Drawn against a 5796×3870 image/;
+const MISMATCH =
+  /drawn against a 5796×3870 image and the selected one is 5616×3744/;
+const ANY_ORIGIN = /drawn against/;
+
+function Harness({
+  maskPreviewImage,
+  maskSourceSize,
+}: {
+  maskPreviewImage?: string;
+  maskSourceSize?: [number, number] | null;
+}) {
+  const form = useForm<pipelineConfig>({
+    defaultValues: { lensMask: PRESET_MASK },
+  });
+
+  return (
+    <TooltipProvider>
+      <LensMaskInput
+        centerX={motionValue(PRESET_MASK.x)}
+        centerY={motionValue(PRESET_MASK.y)}
+        maskPreviewImage={maskPreviewImage}
+        maskSourceSize={maskSourceSize}
+        radius={motionValue(PRESET_MASK.radius)}
+        register={form.register}
+      />
+    </TooltipProvider>
+  );
+}
+
+async function renderMask(props: Parameters<typeof Harness>[0] = {}) {
+  await act(() => {
+    render(<Harness {...props} />);
+    return Promise.resolve();
+  });
+}
+
+describe("LensMaskInput with no preview image selected", () => {
+  it("still shows the mask, so a preset's values do not read as absent", async () => {
+    await renderMask();
+
+    expect(screen.getByText("No image selected")).toBeInTheDocument();
+
+    const radius = screen.getByPlaceholderText("Radius") as HTMLInputElement;
+    const x = screen.getByPlaceholderText("X") as HTMLInputElement;
+    const y = screen.getByPlaceholderText("Y") as HTMLInputElement;
+
+    expect(radius.value).toBe(String(PRESET_MASK.radius));
+    expect(x.value).toBe(String(PRESET_MASK.x));
+    expect(y.value).toBe(String(PRESET_MASK.y));
+  });
+
+  it("names the image size a preset's mask was drawn against", async () => {
+    await renderMask({ maskSourceSize: [5796, 3870] });
+
+    expect(screen.getByText(DRAWN_AGAINST)).toBeInTheDocument();
+  });
+});
+
+describe("LensMaskInput with a preview image selected", () => {
+  it("warns for as long as the mask does not fit the image", async () => {
+    await renderMask({
+      maskPreviewImage: "/fake/image.jpg",
+      maskSourceSize: [5796, 3870],
+    });
+
+    // The toast raised when the preset was applied cannot cover this: the
+    // image may well have been selected after the preset, and it is gone by
+    // the time the mask is looked at either way.
+    expect(screen.getByText(MISMATCH)).toBeInTheDocument();
+  });
+
+  it("stays quiet when the mask was drawn against this same size", async () => {
+    await renderMask({
+      maskPreviewImage: "/fake/image.jpg",
+      maskSourceSize: PREVIEW_SIZE,
+    });
+
+    expect(screen.queryByText(ANY_ORIGIN)).not.toBeInTheDocument();
+  });
+
+  it("stays quiet when the mask has no recorded origin", async () => {
+    await renderMask({ maskPreviewImage: "/fake/image.jpg" });
+
+    expect(screen.queryByText(ANY_ORIGIN)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/preset-applies-lens-mask.test.tsx
+++ b/__tests__/preset-applies-lens-mask.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "@jest/globals";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+
+// jest.mock must be hoisted above the imports below, which the SWC transform
+// only does for the global binding, not one imported from @jest/globals.
+declare const jest: typeof import("@jest/globals").jest;
+
+const PRESET_MASK = { radius: 1800, x: 2808, y: 1935 };
+
+jest.mock("@/lib/presets", () => ({
+  changedSources: () => Promise.resolve([]),
+  deletePreset: () => Promise.resolve(),
+  presetFilePath: () => null,
+  presetId: (name: string) => name,
+  readPresets: () =>
+    Promise.resolve([
+      {
+        files: {},
+        fisheyeView: {
+          horizontalViewDegrees: 180,
+          projection: "vta",
+          verticalViewDegrees: 180,
+        },
+        id: "sigma-8mm",
+        lensMask: PRESET_MASK,
+        lensMaskImageSize: [5616, 3744],
+        name: "Sigma 8mm",
+        outputSettings: { filterIrrelevantSrcImages: false, targetRes: 1000 },
+      },
+    ]),
+  renamePreset: () => Promise.resolve(),
+  savePreset: () => Promise.resolve(),
+}));
+
+jest.mock("@/lib/generic-image-metadata", () => ({
+  useGenericImageMetadata: () => undefined,
+}));
+
+import type { pipelineConfig } from "../src/app/pipeline/(pipeline-configuration)/config-provider";
+import { PresetBar } from "../src/app/pipeline/preset-bar";
+
+// Radix Select drives its trigger with pointer capture and scrolls the active
+// item into view; jsdom implements neither.
+function stubPointerApis() {
+  Element.prototype.hasPointerCapture ||= () => false;
+  Element.prototype.setPointerCapture ||= () => undefined;
+  Element.prototype.releasePointerCapture ||= () => undefined;
+  Element.prototype.scrollIntoView ||= () => undefined;
+}
+
+function Harness({
+  onApplyLensMask,
+}: {
+  onApplyLensMask: (
+    mask: pipelineConfig["lensMask"],
+    drawnAgainst: [number, number] | null
+  ) => void;
+}) {
+  const form = useForm<pipelineConfig>({
+    defaultValues: { lensMask: { radius: 0, x: 0, y: 0 } },
+  });
+
+  return (
+    <PresetBar
+      form={form}
+      maskImagePath={undefined}
+      onApplyLensMask={onApplyLensMask}
+    />
+  );
+}
+
+describe("applying a preset", () => {
+  it("hands the lens mask and its origin to the caller", async () => {
+    stubPointerApis();
+    const applied: {
+      drawnAgainst: [number, number] | null;
+      mask: pipelineConfig["lensMask"];
+    }[] = [];
+
+    render(
+      <Harness
+        onApplyLensMask={(mask, drawnAgainst) => {
+          applied.push({ drawnAgainst, mask });
+        }}
+      />
+    );
+
+    // The listbox opens on a key rather than a click: Radix opens it from
+    // pointerdown, which jsdom has no pointer events to deliver.
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: " " });
+    const item = await screen.findByText("Sigma 8mm");
+    fireEvent.click(item);
+
+    await waitFor(() =>
+      expect(applied).toEqual([
+        { drawnAgainst: [5616, 3744], mask: PRESET_MASK },
+      ])
+    );
+  });
+});

--- a/src/app/pipeline/lens-mask-input.tsx
+++ b/src/app/pipeline/lens-mask-input.tsx
@@ -1,6 +1,6 @@
 import type { MotionValue } from "framer-motion";
 import { Maximize2, MoveHorizontal, MoveVertical, Radius } from "lucide-react";
-import { type ComponentProps, Suspense, use, useState } from "react";
+import { Suspense, use, useState } from "react";
 import type { UseFormRegister } from "react-hook-form";
 import { GenericImage } from "@/components/ui/(image)/generic-image";
 import { Button } from "@/components/ui/button";
@@ -20,16 +20,32 @@ import type { pipelineConfig } from "./(pipeline-configuration)/config-provider"
 import { ScaledCircularMaskSelection } from "./fs-circular-mas-selection";
 import { LensMaskEditor } from "./lens-mask-editor";
 
-export function LensMaskInput({
-  maskPreviewImage,
-  ...props
-}: {
+interface MaskFieldProps {
   centerX: MotionValue<number>;
   centerY: MotionValue<number>;
   radius: MotionValue<number>;
-  maskPreviewImage?: string;
 
   register: UseFormRegister<pipelineConfig>;
+}
+
+/**
+ * The size of the image the current mask was drawn against, when it came from
+ * a preset and has not been touched since.
+ *
+ * The mask is three numbers in image pixels, so it only means the same thing
+ * on an image of the same size. Null once the user has moved it: at that point
+ * they have placed it against what they can see, and the preset's provenance
+ * no longer describes it.
+ */
+type MaskSourceSize = [number, number] | null;
+
+export function LensMaskInput({
+  maskPreviewImage,
+  maskSourceSize,
+  ...props
+}: MaskFieldProps & {
+  maskPreviewImage?: string;
+  maskSourceSize?: MaskSourceSize;
 }) {
   const maskPreviewImageMetadataPromise =
     useGenericImageMetadata(maskPreviewImage);
@@ -40,12 +56,26 @@ export function LensMaskInput({
         <LensMaskInputInner
           maskPreviewImage={maskPreviewImage}
           maskPreviewImageMetadataPromise={maskPreviewImageMetadataPromise}
+          maskSourceSize={maskSourceSize}
           {...props}
         />
       ) : (
-        <p className="grid h-48 w-full place-items-center border-4 border-dashed text-lg text-muted-foreground">
-          No image selected
-        </p>
+        // The numbers stay on screen without a preview. They used to go with
+        // it, so a mask applied from a preset read as absent: the run would
+        // crop to a circle the configuration never showed.
+        <div className="space-y-1">
+          <p className="grid h-48 w-full place-items-center border-4 border-dashed text-center text-lg text-muted-foreground">
+            No image selected
+          </p>
+          <MaskFields {...props} />
+          <p className="text-muted-foreground text-xs">
+            {maskSourceSize
+              ? `Drawn against a ${maskSourceSize[0]}×${maskSourceSize[1]} image. `
+              : ""}
+            These values are applied to the run as they are. Select a preview
+            image to place the mask on it.
+          </p>
+        </div>
       )}
     </Suspense>
   );
@@ -54,16 +84,29 @@ export function LensMaskInput({
 function LensMaskInputInner({
   maskPreviewImage,
   maskPreviewImageMetadataPromise,
+  maskSourceSize,
   centerX,
   centerY,
   radius,
   register,
-}: ComponentProps<typeof LensMaskInput> & {
+}: MaskFieldProps & {
   maskPreviewImage: string;
   maskPreviewImageMetadataPromise: Promise<GenericImageMetadata>;
+  maskSourceSize?: MaskSourceSize;
 }) {
   const maskPreviewImageMetadata = use(maskPreviewImageMetadataPromise);
   const [editorOpen, setEditorOpen] = useState(false);
+
+  // Stays on screen for as long as the mismatch does. The toast raised when
+  // the preset is applied cannot cover the other order -- preset first, image
+  // chosen afterwards -- and there is nothing to warn about at apply time when
+  // no image has been selected yet.
+  const [width, height] = maskPreviewImageMetadata.size;
+  const mismatched =
+    maskSourceSize &&
+    (maskSourceSize[0] !== width || maskSourceSize[1] !== height)
+      ? maskSourceSize
+      : null;
 
   return (
     <div className="space-y-1">
@@ -107,65 +150,89 @@ function LensMaskInputInner({
         open={editorOpen}
         radius={radius}
       />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex gap-1">
-            <Input
-              icon={<Radius />}
-              placeholder="Radius"
-              type="number"
-              {...register("lensMask.radius", {
-                min: {
-                  message: "Radius must be greater than 0",
-                  value: 1,
-                },
-                onChange(e: React.ChangeEvent<HTMLInputElement>) {
-                  const n = Number(e.target.value);
-                  if (Number.isNaN(n)) {
-                    return;
-                  }
-                  radius.set(n);
-                },
-                valueAsNumber: true,
-              })}
-              step="any"
-            />
-            <Input
-              icon={<MoveHorizontal />}
-              placeholder="X"
-              type="number"
-              {...register("lensMask.x", {
-                onChange(e: React.ChangeEvent<HTMLInputElement>) {
-                  const n = Number(e.target.value);
-                  if (Number.isNaN(n)) {
-                    return;
-                  }
-                  centerX.set(n);
-                },
-                valueAsNumber: true,
-              })}
-              step="any"
-            />
-            <Input
-              icon={<MoveVertical />}
-              placeholder="Y"
-              type="number"
-              {...register("lensMask.y", {
-                onChange(e: React.ChangeEvent<HTMLInputElement>) {
-                  const n = Number(e.target.value);
-                  if (Number.isNaN(n)) {
-                    return;
-                  }
-                  centerY.set(n);
-                },
-                valueAsNumber: true,
-              })}
-              step="any"
-            />
-          </div>
-        </TooltipTrigger>
-        <TooltipContent>Values in pixels.</TooltipContent>
-      </Tooltip>
+      <MaskFields
+        centerX={centerX}
+        centerY={centerY}
+        radius={radius}
+        register={register}
+      />
+      {mismatched ? (
+        <p className="text-amber-600 text-xs">
+          This mask was drawn against a {mismatched[0]}×{mismatched[1]} image
+          and the selected one is {width}×{height}. Check it before running.
+        </p>
+      ) : null}
     </div>
+  );
+}
+
+/**
+ * The mask as three numbers.
+ *
+ * Rendered whether or not a preview image is selected, so the mask is always
+ * legible: it is what the run actually uses, and the preview is only a way to
+ * set it.
+ */
+function MaskFields({ centerX, centerY, radius, register }: MaskFieldProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex gap-1">
+          <Input
+            icon={<Radius />}
+            placeholder="Radius"
+            type="number"
+            {...register("lensMask.radius", {
+              min: {
+                message: "Radius must be greater than 0",
+                value: 1,
+              },
+              onChange(e: React.ChangeEvent<HTMLInputElement>) {
+                const n = Number(e.target.value);
+                if (Number.isNaN(n)) {
+                  return;
+                }
+                radius.set(n);
+              },
+              valueAsNumber: true,
+            })}
+            step="any"
+          />
+          <Input
+            icon={<MoveHorizontal />}
+            placeholder="X"
+            type="number"
+            {...register("lensMask.x", {
+              onChange(e: React.ChangeEvent<HTMLInputElement>) {
+                const n = Number(e.target.value);
+                if (Number.isNaN(n)) {
+                  return;
+                }
+                centerX.set(n);
+              },
+              valueAsNumber: true,
+            })}
+            step="any"
+          />
+          <Input
+            icon={<MoveVertical />}
+            placeholder="Y"
+            type="number"
+            {...register("lensMask.y", {
+              onChange(e: React.ChangeEvent<HTMLInputElement>) {
+                const n = Number(e.target.value);
+                if (Number.isNaN(n)) {
+                  return;
+                }
+                centerY.set(n);
+              },
+              valueAsNumber: true,
+            })}
+            step="any"
+          />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>Values in pixels.</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/app/pipeline/page.tsx
+++ b/src/app/pipeline/page.tsx
@@ -292,6 +292,31 @@ export default function Home() {
     "lensMask.radius"
   );
 
+  // The image size the current mask was drawn against, carried from the preset
+  // it came from so the mask input can say whether it still fits the selected
+  // image.
+  const [maskSourceSize, setMaskSourceSize] = useState<[number, number] | null>(
+    null
+  );
+
+  // Any movement of the mask drops that provenance: once the user has placed
+  // the circle against an image themselves, where it originally came from no
+  // longer describes it, and a warning about the old size would be nagging
+  // about something they have already dealt with.
+  useEffect(() => {
+    const forget = () => setMaskSourceSize(null);
+    const unsubscribe = [
+      centerX.on("change", forget),
+      centerY.on("change", forget),
+      radius.on("change", forget),
+    ];
+    return () => {
+      for (const stop of unsubscribe) {
+        stop();
+      }
+    };
+  }, [centerX, centerY, radius]);
+
   const [progressVisible, setProgressVisible] = useState(false);
   const [consoleOpen, setConsoleOpen] = useState(false);
   const { beginSet, clearLog, getOutputs, log, setTotal } = usePipelineStatus();
@@ -600,7 +625,19 @@ export default function Home() {
           <ResizableHandle withHandle />
           <ResizablePanel>
             <div className="flex h-full min-h-0 flex-col bg-accent">
-              <PresetBar form={form} maskImagePath={selectedImage} />
+              <PresetBar
+                form={form}
+                maskImagePath={selectedImage}
+                onApplyLensMask={(mask, drawnAgainst) => {
+                  // Setting the motion values notifies the listener above
+                  // synchronously, so the size the preset recorded is stored
+                  // after them rather than being cleared by them.
+                  centerX.set(mask.x);
+                  centerY.set(mask.y);
+                  radius.set(mask.radius);
+                  setMaskSourceSize(drawnAgainst);
+                }}
+              />
               <Accordion
                 className="min-h-0 flex-1 overflow-y-auto"
                 collapsible
@@ -741,6 +778,7 @@ export default function Home() {
                         centerX={centerX}
                         centerY={centerY}
                         maskPreviewImage={selectedImage}
+                        maskSourceSize={maskSourceSize}
                         radius={radius}
                         register={register}
                       />

--- a/src/app/pipeline/preset-bar.tsx
+++ b/src/app/pipeline/preset-bar.tsx
@@ -77,9 +77,26 @@ const SLOT_LABEL: Record<PresetFileSlot, string> = {
 export function PresetBar({
   form,
   maskImagePath,
+  onApplyLensMask,
 }: {
   form: UseFormReturn<pipelineConfig>;
   maskImagePath: string | undefined;
+  /**
+   * Moves the drawn mask onto the preset's values.
+   *
+   * The circle is rendered from motion values, which are written to the form
+   * but never read back from it, so setting the form alone left the preview
+   * showing the previous mask while the fields showed the preset's.
+   *
+   * `drawnAgainst` is the image size the mask was saved against, which the
+   * mask input needs to say whether it still fits the selected image. It is
+   * null for a preset saved with no image selected, where there was nothing to
+   * record.
+   */
+  onApplyLensMask?: (
+    mask: pipelineConfig["lensMask"],
+    drawnAgainst: [number, number] | null
+  ) => void;
 }) {
   const [presets, setPresets] = useState<Preset[]>([]);
   const [selectedId, setSelectedId] = useState<string>("");
@@ -136,6 +153,7 @@ export function PresetBar({
     form.setValue("outputSettings", preset.outputSettings);
     if (preset.lensMask) {
       form.setValue("lensMask", preset.lensMask);
+      onApplyLensMask?.(preset.lensMask, preset.lensMaskImageSize);
     }
     form.setValue("cameraResponseLocation", presetFilePath(preset, "response"));
     form.setValue("correctionFiles", {


### PR DESCRIPTION
## The problem

Loading a preset applies its lens mask, but with no preview image clicked there was nothing on screen showing it. The radius/x/y fields lived only in the branch of `LensMaskInput` that draws the preview, so the mask read as absent while `build-pipeline-params.ts` was still going to crop the run to that circle.

Two further problems turned up alongside it:

- **Applying a preset never moved the drawn circle.** `useMotionValueFormState` syncs the motion values into the form and never back out of it, so `setValue("lensMask", ...)` updated the fields while the circle stayed where it was. The next drag then wrote the stale centre back over the preset's values.
- **The size-mismatch warning depended on timing.** It was a toast raised at apply time, and only when an image happened to be selected right then. Applying a preset first and choosing an image afterwards, which is the case that started this, never warned at all.

## The changes

- `lens-mask-input.tsx` — the three inputs moved into a `MaskFields` component rendered in both branches. Without a preview there is now the placeholder, the values, and a line saying they apply as they are.
- `preset-bar.tsx` / `page.tsx` — `PresetBar` hands the applied mask and the size it was drawn against to the page, which sets the three motion values so the circle, the fields and the form agree.
- The recorded size is shown beside the mask and, when it does not match the selected image, as a warning that persists for as long as it holds. It is dropped as soon as the user moves the circle: at that point they have placed it against what they can see, and the preset's provenance no longer describes it. The apply-time toast is unchanged, since the inline warning sits inside an accordion section that may be collapsed.

## Testing

- `__tests__/lens-mask-without-image.test.tsx` — the mask is legible with no image; the recorded size is named; the mismatch warning appears only when the sizes actually differ.
- `__tests__/preset-applies-lens-mask.test.tsx` — applying a preset hands the mask and its origin to the caller. Confirmed to fail against the previous code.
- Full suite: 61 files, 406 tests passing. `tsc --noEmit` and `ultracite check` clean, aside from one pre-existing warning in the RAW conversion loop.

Note that `e2e-tests/test/specs/app.e2e.ts` has a comment explaining that it clicks a preview image purely so the mask fields exist in the DOM. That workaround is no longer necessary, though the test still passes as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)