### PR TITLE
fix(ci): restore tauri.conf.json's formatting, broken by the 5.0.0 bump

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,9 +25,7 @@
       "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost https://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "**"
-        ]
+        "scope": ["**"]
       }
     }
   },


### PR DESCRIPTION
**`main` is currently failing lint.** One line, one file.

#262 edited the version with a JSON serializer, which re-serialised the whole document and expanded `"scope": ["**"]` across three lines. Biome's formatter wants it inline, so `npm run lint` has failed on `main` since that merge and every branch cut from it inherits the failure.

```diff
-        "scope": [
-          "**"
-        ]
+        "scope": ["**"]
```

That is the entire change. Versions are untouched and still agree at 5.0.0 across `package.json`, `tauri.conf.json` and `Cargo.toml`, so `release.yml`'s check still passes.

## How it got in

#262's CI was reported as passing when only the two Vercel checks had reported; the Actions run failed and was not re-read before the merge. Visible now in the run list as `chore(release): 5.0.0 — CI (web) — failure`.

## Worth remembering

A version bump has no business reformatting the file it edits. Doing this by hand, or with a targeted replacement rather than a round-trip through a JSON serializer, avoids the whole class.

Blocks #263, which is otherwise green: its end-to-end jobs pass on both engines and only this inherited lint error fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)