### PR TITLE
Refuse a run with no output folder, say where results went, quieten the log

### DIFF
--- a/__tests__/preflight.test.ts
+++ b/__tests__/preflight.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 import type { pipelineConfig } from "@/app/pipeline/(pipeline-configuration)/config-provider";
-import { describeRunBlocker } from "@/app/pipeline/preflight";
+import {
+  describeRunBlocker,
+  describeRunProblem,
+} from "@/app/pipeline/preflight";
 
 /** The example Canon 5D Mark III CR2s, as dcraw_emu renders them. */
 const CR2: [number, number] = [5796, 3870];
@@ -84,5 +87,58 @@ describe("describeRunBlocker", () => {
     const config = makeConfig({ lensMask: { radius: 0, x: 0, y: 0 } });
 
     expect(describeRunBlocker(config, CR2)).toContain("Lens mask radius");
+  });
+});
+
+const MENTIONS_SETTINGS = /Settings/;
+const MENTIONS_RADIUS = /radius/i;
+
+describe("describeRunProblem", () => {
+  // The suite injects `__TAURI_INTERNALS__`, so the host reads as desktop
+  // unless a case removes it. That is the half where an output folder exists
+  // to be wrong about.
+  it("reports an output folder that is not there", async () => {
+    const problem = await describeRunProblem(
+      makeConfig(),
+      CR2,
+      "/gone/missing"
+    );
+    expect(problem).toContain("/gone/missing");
+    expect(problem).toMatch(MENTIONS_SETTINGS);
+  });
+
+  // The app fills this in at startup, so an empty value means "not resolved
+  // yet" rather than "wrong". Refusing to run on it would block a first run.
+  it("says nothing when no folder has been chosen yet", async () => {
+    await expect(describeRunProblem(makeConfig(), CR2, "")).resolves.toBeNull();
+  });
+
+  // A browser has no output folder to be wrong about: the download lands
+  // wherever the browser decides, so there is nothing here to check.
+  it("finds no problem in a browser, whatever the path says", async () => {
+    // `isTauri` tests for the key's presence, so it has to leave rather than
+    // be set to undefined. Reflect.deleteProperty says that without tripping
+    // the lint rule against `delete`.
+    const host = globalThis as Record<string, unknown>;
+    const internals = host.__TAURI_INTERNALS__;
+    Reflect.deleteProperty(host, "__TAURI_INTERNALS__");
+    try {
+      await expect(
+        describeRunProblem(makeConfig(), CR2, "/gone/missing")
+      ).resolves.toBeNull();
+    } finally {
+      host.__TAURI_INTERNALS__ = internals;
+    }
+  });
+
+  // Answered from the configuration alone, so it is reported without the
+  // filesystem being consulted at all.
+  it("reports a configuration blocker ahead of the folder", async () => {
+    const problem = await describeRunProblem(
+      makeConfig({ lensMask: { radius: 0, x: 100, y: 100 } }),
+      CR2,
+      "/gone/missing"
+    );
+    expect(problem).toMatch(MENTIONS_RADIUS);
   });
 });

--- a/e2e-tests/test/specs/app.e2e.ts
+++ b/e2e-tests/test/specs/app.e2e.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { $, browser } from "@wdio/globals";
-import { describe, it } from "mocha";
+import { after, describe, it } from "mocha";
 
 const E2E_DROP_EVENT = "__lumilab_e2e_drop__";
 const jpegInputDirectory = fileURLToPath(
@@ -183,6 +183,39 @@ async function setTextInputValue(selector: string, value: string) {
   );
 }
 
+/**
+ * The settings this suite found before it changed anything.
+ *
+ * The desktop app and this suite share one Tauri identifier, which is
+ * deliberate -- renaming it would orphan every user's presets and history --
+ * but it means they also share one `localStorage`. Writing an output folder
+ * here therefore writes it into the real application on the developer's own
+ * machine, and leaving it there points their installed build at a temporary
+ * directory that will not exist next week.
+ *
+ * That is not hypothetical: a path from a run predating the LumiLab rename was
+ * still in a released build's settings months later, and the first run after
+ * it failed with `failed to open file at path: ... (os error 2)` once the whole
+ * pipeline had already finished.
+ */
+let settingsBeforeSuite: string | null = null;
+
+async function rememberPersistedSettings() {
+  settingsBeforeSuite = await browser.execute(
+    () => window.localStorage.getItem("hdr-settings") ?? null
+  );
+}
+
+async function restorePersistedSettings() {
+  await browser.execute((previous: string | null) => {
+    if (previous === null) {
+      window.localStorage.removeItem("hdr-settings");
+      return;
+    }
+    window.localStorage.setItem("hdr-settings", previous);
+  }, settingsBeforeSuite);
+}
+
 async function setPersistedSettings(nextSettings: { outputPath?: string }) {
   await browser.execute((settingsPatch) => {
     const storageKey = "hdr-settings";
@@ -342,6 +375,13 @@ function getPipelineFailureMessage(outputDir: string): string | null {
 }
 
 describe("LumiLab", () => {
+  // Runs whether or not the suite passed. A failed run is exactly when the
+  // developer's own settings would otherwise be left pointing at a temporary
+  // directory, because nothing later in the suite would have put them back.
+  after(async () => {
+    await restorePersistedSettings();
+  });
+
   it("opens to the home page", async () => {
     await browser.waitUntil(
       async () => (await browser.getUrl()).endsWith("/pipeline"),
@@ -378,6 +418,7 @@ describe("LumiLab", () => {
   const generatesHdr = process.platform === "win32" ? it.skip : it;
 
   generatesHdr("generates an HDR image", async () => {
+    await rememberPersistedSettings();
     await setPersistedSettings({ outputPath: tempOutputDirectory });
     await browser.refresh();
     await browser.waitUntil(

--- a/src/app/pipeline/page.tsx
+++ b/src/app/pipeline/page.tsx
@@ -81,7 +81,7 @@ import { unsuppliedCalibrationFiles } from "./calibration-files";
 import { LensMaskInput } from "./lens-mask-input";
 import { useGlobalPipelineConfig } from "./pipeline-config-store";
 import { PipelineStatus } from "./pipeline-status";
-import { describeRunBlocker } from "./preflight";
+import { describeRunProblem } from "./preflight";
 import { PresetBar } from "./preset-bar";
 import { describeBatchSummary, runBatch, type SetPosition } from "./run-batch";
 import {
@@ -467,10 +467,18 @@ export default function Home() {
             // what every set is run with. Deliberately not per set: the mask
             // is checked against the selected preview image only, and
             // validating each set's own dimensions is separate work.
-            const blocker = describeRunBlocker(data, maskSize);
-            if (blocker) {
-              toast.error(blocker);
-              await recordAttempt(blocker, [], [], "", 1, logAtSubmit);
+            // Includes the output folder, checked before the work rather than
+            // after it. A missing folder used to surface as a raw filesystem
+            // error once every stage had already run, throwing away the whole
+            // pipeline and saying nothing about which folder was wrong.
+            const problem = await describeRunProblem(
+              data,
+              maskSize,
+              settings.outputPath
+            );
+            if (problem) {
+              toast.error(problem);
+              await recordAttempt(problem, [], [], "", 1, logAtSubmit);
               return;
             }
 

--- a/src/app/pipeline/preflight.ts
+++ b/src/app/pipeline/preflight.ts
@@ -1,3 +1,4 @@
+import { describeOutputFolderProblem } from "@/lib/host/save";
 import type { pipelineConfig } from "./(pipeline-configuration)/config-provider";
 import { maskBox } from "./build-pipeline-params";
 import { describeMaskOverflow } from "./lens-mask-fit";
@@ -44,4 +45,24 @@ export function describeRunBlocker(
   // crop stage would catch part of this, but only after every exposure has
   // been merged, which is the expensive part of a run.
   return maskSize ? describeMaskOverflow(maskBox(data), maskSize) : null;
+}
+
+/**
+ * The first reason this run cannot start, or null if it can.
+ *
+ * One gate rather than two. `describeRunBlocker` is pure and answers from the
+ * configuration alone; the output folder can only be answered by asking the
+ * filesystem, and on a browser there is no folder to ask about. Callers want
+ * "can this run start", so the split is an implementation detail rather than
+ * something every caller should have to remember to check twice.
+ */
+export async function describeRunProblem(
+  data: pipelineConfig,
+  maskSize: [width: number, height: number] | null,
+  outputPath: string
+): Promise<string | null> {
+  return (
+    describeRunBlocker(data, maskSize) ??
+    (await describeOutputFolderProblem(outputPath))
+  );
 }

--- a/src/app/pipeline/run-wasm-pipeline.ts
+++ b/src/app/pipeline/run-wasm-pipeline.ts
@@ -204,21 +204,24 @@ export async function runWasmPipeline({
     // biome-ignore lint/performance/noAwaitInLoops: each output is announced only after it has been written, which is what lets a failed set be attributed correctly
     const saved = await host.save(params.outputPath, name, bytes);
     const destination = saved.location;
-    if (saved.downloaded) {
-      // Said explicitly because a download is invisible: the browser chooses
-      // where it lands, and without this the run reports success while the
-      // user has no idea whether anything was produced or where it went.
-      host
-        .emitStatus({
-          kind: "step",
-          message: `Downloaded ${saved.name} to your browser's downloads folder`,
-          progress: null,
-          step: "save_output",
-        })
-        .catch(() => {
-          // A dropped status line must never fail the run that produced it.
-        });
-    }
+    // Said explicitly in both hosts, because where a file went is invisible
+    // either way. A browser chooses the folder itself. On the desktop the
+    // folder is a setting, which can be stale for ordinary reasons -- a drive
+    // that is not mounted, a directory since deleted, a value left behind by
+    // something else -- and a run that says only "complete" gives a user no
+    // way to notice their results went somewhere they will never look.
+    host
+      .emitStatus({
+        kind: "step",
+        message: saved.downloaded
+          ? `Downloaded ${saved.name} to your browser's downloads folder`
+          : `Saved ${saved.name} to ${destination}`,
+        progress: null,
+        step: "save_output",
+      })
+      .catch(() => {
+        // A dropped status line must never fail the run that produced it.
+      });
     if (announce) {
       // Announced after the write, matching the Rust pipeline: a set that
       // failed has announced no outputs, which is what run history relies on.

--- a/src/lib/host/save.ts
+++ b/src/lib/host/save.ts
@@ -37,6 +37,39 @@ export interface SavedOutput {
  * `directory` is ignored in a browser, where there is nowhere to put it but
  * the download folder.
  */
+/**
+ * Why the configured output folder cannot be written to, or null if it can.
+ *
+ * Checked before a run rather than after, because the alternative is what
+ * happened in practice: a full pipeline completed, then the first write failed
+ * with `failed to open file at path: ... (os error 2)`, and the work was lost
+ * with nothing said about which folder was wrong or where to change it.
+ *
+ * The folder can be stale for ordinary reasons -- an external drive that is
+ * not mounted, a directory since deleted, a path restored from a backup -- and
+ * the setting is persistent, so a wrong value keeps failing every run until
+ * someone notices it.
+ *
+ * Browsers have no output folder to check: the download lands wherever the
+ * browser decides, so there is nothing here to be wrong.
+ */
+export async function describeOutputFolderProblem(
+  directory: string
+): Promise<string | null> {
+  if (!(isTauri() && directory)) {
+    return null;
+  }
+  const { exists } = await import("@tauri-apps/plugin-fs");
+  try {
+    if (await exists(directory)) {
+      return null;
+    }
+  } catch (error) {
+    return `Could not check the output folder ${directory}: ${error}. Choose another in Settings.`;
+  }
+  return `The output folder ${directory} does not exist, so there is nowhere to save the results. Choose another in Settings.`;
+}
+
 export async function saveOutput(
   directory: string,
   name: string,

--- a/src/lib/pipeline/pipeline.worker.ts
+++ b/src/lib/pipeline/pipeline.worker.ts
@@ -32,15 +32,6 @@ import {
 
 declare const self: DedicatedWorkerGlobalScope;
 
-/**
- * Below this, a tool invocation is not worth a line in the run console.
- *
- * One second is comfortably above anything healthy -- a whole 18-frame merge
- * is around fifteen -- so a quiet log means nothing was slow, and any line at
- * all is a stage worth looking at.
- */
-const SLOW_TOOL_MS = 1000;
-
 function post(message: PipelineWorkerMessage, transfer: Transferable[] = []) {
   self.postMessage(message, transfer);
 }
@@ -144,12 +135,14 @@ async function run(request: PipelineRunRequest): Promise<void> {
   const runner = new WasmToolRunner({
     compile: urlModuleCompiler(request.wasmBaseUrl),
     load: urlModuleLoader(request.wasmBaseUrl),
-    // A tool only explains itself when it was slow. A run where everything is
-    // quick says nothing, and a run where one stage takes minutes says which
-    // part of it did: fetching the module, compiling it, or computing. That
-    // distinction is the difference between a hosting problem and a build one,
-    // and it cannot be recovered afterwards from wall-clock timestamps alone.
+    // To the console, not the run log. The breakdown is what tells a hosting
+    // problem from a build one, and it is worth keeping for that, but every
+    // real run has a stage that legitimately takes tens of seconds -- the
+    // merge is a single invocation -- so surfacing it to users meant a line of
+    // diagnostics beside every normal run. Developers open the console; users
+    // should not have to read past this to find their own output.
     onTiming: (timing) => {
+      const ms = (value: number) => `${(value / 1000).toFixed(1)}s`;
       const total =
         timing.loadMs +
         timing.compileMs +
@@ -157,22 +150,11 @@ async function run(request: PipelineRunRequest): Promise<void> {
         timing.stageMs +
         timing.runMs +
         timing.collectMs;
-      if (total < SLOW_TOOL_MS) {
-        return;
-      }
-      const ms = (value: number) => `${(value / 1000).toFixed(1)}s`;
-      post({
-        kind: "status",
-        payload: {
-          kind: "step",
-          message:
-            `${timing.tool} took ${ms(total)}: fetch+compile ${ms(timing.loadMs + timing.compileMs)}, ` +
-            `instantiate ${ms(timing.instantiateMs)}, stage ${ms(timing.stageMs)}, ` +
-            `run ${ms(timing.runMs)}, collect ${ms(timing.collectMs)}`,
-          progress: null,
-          step: "timing",
-        },
-      });
+      console.debug(
+        `${timing.tool} took ${ms(total)}: fetch+compile ${ms(timing.loadMs + timing.compileMs)}, ` +
+          `instantiate ${ms(timing.instantiateMs)}, stage ${ms(timing.stageMs)}, ` +
+          `run ${ms(timing.runMs)}, collect ${ms(timing.collectMs)}`
+      );
     },
   });
 


### PR DESCRIPTION
Three faults from one report against the 5.0.0 build, plus the cause of the first.

## A run wrote nowhere, and only said so afterwards

The configured output folder pointed at a temporary directory that no longer existed. The pipeline ran every stage, then failed on the first write:

```
Failed
failed to open file at path: /var/folders/.../T/hdricalibrationtool-e2e-BIYaSd/JPEG_2026-08-07_11-37-06.hdr
with error: No such file or directory (os error 2)
```

Thirty seconds of work discarded, and nothing said about which folder was wrong or where to change it. The folder is now checked **before** the run starts, and the message names the folder and points at Settings.

Folders go stale for ordinary reasons: an unmounted drive, a deleted directory, a path restored from a backup. The setting is persistent, so a wrong value fails every run until someone notices.

## Neither host said where the results went

A browser announced its download. The desktop said nothing at all, which is why a wrong folder could stay invisible indefinitely. Both now report the destination:

```
Saved JPEG_2026-08-07_11-37-06.hdr to /Users/…/Documents/LumiLab/…
```

## Every run carried diagnostics nobody asked for

#263 reported a per-tool breakdown whenever an invocation passed one second, on the reasoning that "a whole merge is around fifteen seconds and no single invocation should approach that". That was simply wrong: the merge **is** a single invocation, so hdrgen tripped it on every run, along with evalglare and pcomb.

The breakdown moves to `console.debug` — still there for whoever needs it, in front of nobody who does not. The JIT warning stays in the run log, because that one is actionable.

## The cause of the stale folder

The desktop end-to-end suite writes an output path into `hdr-settings`, which is the same key the real app uses, because both share one Tauri identifier. That sharing is deliberate and must stay: renaming the identifier would orphan every user's presets and history. But the suite never put the value back, so a temporary directory from a run predating the LumiLab rename was still in a released build's settings months later.

It now restores what it found, in an `after` hook so a failed run cleans up too — which is exactly when it matters, since nothing later in the suite would.

## Verification

435 tests (4 new, covering the missing folder, the not-yet-chosen folder, the browser case, and blocker precedence), `tsc` clean in all three projects, lint clean, and the full browser end-to-end suite passing.

Note for anyone hitting this on an existing install: changing the output folder in Settings fixes it immediately; this PR is about the app telling you rather than failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)